### PR TITLE
X番地Y号の住所に対応

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -33,9 +33,7 @@ test('京都府京都市中京区寺町通御池上る上本能寺前町488番�
 })
 
 test('京都府京都市中京区上本能寺前町488', async () => {
-  const res = await normalize(
-    '京都府京都市中京区上本能寺前町488',
-  )
+  const res = await normalize('京都府京都市中京区上本能寺前町488')
   expect(res).toBe('京都府京都市中京区上本能寺前町488')
 })
 
@@ -85,7 +83,9 @@ test('栃木県佐野市七軒町2201', async () => {
 })
 
 test('京都府京都市東山区大和大路通三条下る東入若松町393', async () => {
-  const res = await normalize('京都府京都市東山区大和大路通三条下る東入若松町393')
+  const res = await normalize(
+    '京都府京都市東山区大和大路通三条下る東入若松町393',
+  )
   expect(res).toBe('京都府京都市東山区若松町393')
 })
 
@@ -118,4 +118,9 @@ test('岩手県滝沢市後２６８−５６６', async () => {
 test('青森県五所川原市金木町喜良市千苅６２−８', async () => {
   const res = await normalize('青森県五所川原市金木町喜良市千苅６２−８')
   expect(res).toBe('青森県五所川原市金木町喜良市千苅62-8')
+})
+
+test('岩手県盛岡市盛岡駅西通２丁目９番地１号', async () => {
+  const res = await normalize('岩手県盛岡市盛岡駅西通２丁目９番地１号')
+  expect(res).toBe('岩手県盛岡市盛岡駅西通2丁目9-1')
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
 import os from 'os'
 import path from 'path'
-import { kanji2number, number2kanji, findKanjiNumbers } from '@geolonia/japanese-numeral'
+import {
+  kanji2number,
+  number2kanji,
+  findKanjiNumbers,
+} from '@geolonia/japanese-numeral'
 const tmpdir = path.join(os.tmpdir(), 'normalize-japanese-addresses')
 const fetch = require('node-fetch-cache')(tmpdir)
 import dict from './lib/dict'
@@ -109,7 +113,12 @@ export const normalize = async (address: string) => {
       return kan2num(s) // API からのレスポンスに含まれる `n丁目` 等の `n` を数字に変換する。
     })
 
-    const regex = new RegExp(_town.replace(/([0-9]+)(丁目|丁|番町|条|軒|線|の町|号|地割|-)/ig, `$1${units}`))
+    const regex = new RegExp(
+      _town.replace(
+        /([0-9]+)(丁目|丁|番町|条|軒|線|の町|号|地割|-)/gi,
+        `$1${units}`,
+      ),
+    )
     const match = addr.match(regex)
     if (match) {
       town = kan2num(towns[i])
@@ -127,8 +136,9 @@ export const normalize = async (address: string) => {
     throw new Error("Can't detect the town.")
   }
 
-  addr = addr.replace(/([(0-9]+)番([0-9]+)号/, '$1-$2')
-          .replace(/([0-9]+)番地/, '$1')
+  addr = addr
+    .replace(/([(0-9]+)(番|番地)([0-9]+)号/, '$1-$3')
+    .replace(/([0-9]+)番地/, '$1')
 
   return pref + city + town + addr
 }


### PR DESCRIPTION
Fix #40 

現状、`X番Y号` の住所には対応しているが、`X番地Y号` の住所を正規化できていないので修正。

リントが入って見にくいですが、修正点は[140行目](https://github.com/geolonia/normalize-japanese-addresses/pull/41/files#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR140) です。