### PR TITLE
`富山県富山市三番町1-23` を `富山県富山市3-1-23` のように記述したときの不具合の修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -114,12 +114,24 @@ export const normalize: (input: string) => Promise<NormalizeResult> = async (add
   addr = addr.trim()
 
   for (let i = 0; i < towns.length; i++) {
-    const regex1 = new RegExp(
-      towns[i].replace(
-        /([0-9]+)(丁目|丁|番町|条|軒|線|の町|号|地割|の|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])/gi,
-        `$1${units}`,
-      ),
-    )
+    let regex1, regex2
+
+    // 京都は通り名があるので後方でマッチさせる。京都以外は先頭でマッチ。
+    if ('京都') {
+      regex1 = new RegExp(
+        towns[i].replace(
+          /([0-9]+)(丁目|丁|番町|条|軒|線|の町|号|地割|の|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])/gi,
+          `$1${units}`,
+        ),
+      )
+    } else {
+      regex1 = new RegExp(
+        '^' + towns[i].replace(
+          /([0-9]+)(丁目|丁|番町|条|軒|線|の町|号|地割|の|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])/gi,
+          `$1${units}`,
+        ),
+      )
+    }
 
     const reg = new RegExp(`[〇一二三四五六七八九十百千]+${units}`, 'g')
 
@@ -127,12 +139,22 @@ export const normalize: (input: string) => Promise<NormalizeResult> = async (add
       return kan2num(s) // API からのレスポンスに含まれる `n丁目` 等の `n` を数字に変換する。
     })
 
-    const regex2 = new RegExp(
-      _town.replace(
-        /([0-9]+)(丁目?|番町|条|軒|線|の町?|号|地割|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])/gi,
-        `$1${units}`,
-      ),
-    )
+    // 京都は通り名があるので後方でマッチさせる。京都以外は先頭でマッチ。
+    if ('京都' === pref) {
+      regex2 = new RegExp(
+        _town.replace(
+          /([0-9]+)(丁目?|番町|条|軒|線|の町?|号|地割|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])/gi,
+          `$1${units}`,
+        ),
+      )
+    } else {
+      regex2 = new RegExp(
+        '^' + _town.replace(
+          /([0-9]+)(丁目?|番町|条|軒|線|の町?|号|地割|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])/gi,
+          `$1${units}`,
+        ),
+      )
+    }
 
     const match1 = dict(zen2han(addr)).match(regex1) // n丁目などのnの部分を漢数字にした場合のパターンマッチ
     const match2 = dict(zen2han(addr)).match(regex2) // n丁目などのnの部分を数字にした場合のパターンマッチ

--- a/test/buildings.test.ts
+++ b/test/buildings.test.ts
@@ -15,7 +15,7 @@ for (let i = 0; i < data.length; i++) {
     const res = await normalize(address)
     expect(!! res.pref).toStrictEqual(true)
     expect(!! res.city).toStrictEqual(true)
-    // expect(!! res.town).toStrictEqual(true)
+    expect(!! res.town).toStrictEqual(true)
     expect(!! res.addr).toStrictEqual(true)
   })
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -323,3 +323,8 @@ test('富山県富山市3-1-23', async () => {
   const res = await normalize('富山県富山市3-1-23')
   expect(res).toStrictEqual({"pref": "富山県", "city": "富山市", "town": "三番町", "addr": "1-23"})
 })
+
+test('富山県富山市中央通り3-1-23', async () => {
+  const res = await normalize('富山県富山市中央通り3-1-23')
+  expect(res).toStrictEqual({"pref": "富山県", "city": "富山市", "town": "中央通り三丁目", "addr": "1-23"})
+})

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -313,3 +313,13 @@ test('東京都町田市木曽東４ー１４ーイ２２', async () => {
   const res = await normalize('東京都町田市木曽東４ー１４ーイ２２')
   expect(res).toStrictEqual({"pref": "東京都", "city": "町田市", "town": "木曽東四丁目", "addr": "14-イ22"})
 })
+
+test('富山県富山市三番町1番23号', async () => {
+  const res = await normalize('富山県富山市三番町1番23号')
+  expect(res).toStrictEqual({"pref": "富山県", "city": "富山市", "town": "三番町", "addr": "1-23"})
+})
+
+test('富山県富山市3-1-23', async () => {
+  const res = await normalize('富山県富山市3-1-23')
+  expect(res).toStrictEqual({"pref": "富山県", "city": "富山市", "town": "三番町", "addr": "1-23"})
+})


### PR DESCRIPTION
京都以外は町名を先頭でマッチさせるべきである一方、京都は通り名が入りうるため後方からマッチさせるべきで、そのための条件分岐を追加した。