### PR TITLE
`一ノ町`とか`十一番町`などの例外的な街区分けに対応

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -127,8 +127,7 @@ export const normalize: (input: string) => Promise<NormalizeResult> = async (
   for (let i = 0; i < towns.length; i++) {
     const regex = toRegex(
       towns[i]
-        .replace(/字/g, '字?')
-        .replace(/大字/g, '(大字)?')
+        .replace(/大?字/g, '(大?字)?')
         // 以下住所マスターの町丁目に含まれる数字を正規表現に変換する
         .replace(
           /([壱一二三四五六七八九十]+)(丁目?|番町|条|軒|線|(の|ノ)町|地割)/g,

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,7 +131,7 @@ export const normalize: (input: string) => Promise<NormalizeResult> = async (
         .replace(/大字/g, '(大字)?')
         // 以下住所マスターの町丁目に含まれる数字を正規表現に変換する
         .replace(
-          /([一二三四五六七八九十]+)(丁目?|番町|条|軒|線|(の|ノ)町|地割)/g,
+          /([壱一二三四五六七八九十]+)(丁目?|番町|条|軒|線|(の|ノ)町|地割)/g,
           (match: string) => {
             const regexes = []
 
@@ -141,20 +141,27 @@ export const normalize: (input: string) => Promise<NormalizeResult> = async (
                 .replace(/(丁目?|番町|条|軒|線|(の|ノ)町|地割)/, ''),
             ) // 漢数字
 
-            const num = match
-              .replace(/([一二三四五六七八九十]+)/g, (match) => {
-                return kan2num(match)
-              })
-              .replace(/(丁目?|番町|条|軒|線|(の|ノ)町|地割)/, '')
-            regexes.push(num.toString()) // 半角アラビア数字
-            regexes.push(
-              String.fromCharCode(num.toString().charCodeAt(0) + 0xfee0),
-            ) // 全角アラビア数字
+            if (match.match(/^壱/)) {
+              regexes.push('一')
+              regexes.push('1')
+              regexes.push('１')
+            } else {
+              const num = match
+                .replace(/([一二三四五六七八九十]+)/g, (match) => {
+                  return kan2num(match)
+                })
+                .replace(/(丁目?|番町|条|軒|線|(の|ノ)町|地割)/, '')
+
+              regexes.push(num.toString()) // 半角アラビア数字
+              regexes.push(
+                String.fromCharCode(num.toString().charCodeAt(0) + 0xfee0),
+              ) // 全角アラビア数字
+            }
 
             // 以下の正規表現は、上のよく似た正規表現とは違うことに注意！
             return `(${regexes.join(
               '|',
-            )})(丁目?|番町|条|軒|線|の町?|地割|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])`
+            )})((丁|町)目?|番町|条|軒|線|の町?|地割|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])`
           },
         ),
     )

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,9 +122,7 @@ export const normalize: (input: string) => Promise<NormalizeResult> = async (
   let town = ''
 
   // `1丁目` 等の文字列を `一丁目` に変換
-  addr = addr
-    .trim()
-    .replace(/^大字/, '')
+  addr = addr.trim().replace(/^大字/, '')
 
   for (let i = 0; i < towns.length; i++) {
     const regex = toRegex(
@@ -132,20 +130,33 @@ export const normalize: (input: string) => Promise<NormalizeResult> = async (
         .replace(/字/g, '字?')
         .replace(/大字/g, '(大字)?')
         // 以下住所マスターの町丁目に含まれる数字を正規表現に変換する
-        .replace(/([一二三四五六七八九十]+)(丁目?|番町|条|軒|線|(の|ノ)町|地割)/g, (match: String) => {
-          const regexes = []
+        .replace(
+          /([一二三四五六七八九十]+)(丁目?|番町|条|軒|線|(の|ノ)町|地割)/g,
+          (match: string) => {
+            const regexes = []
 
-          regexes.push(match.toString().replace(/(丁目?|番町|条|軒|線|(の|ノ)町|地割)/, '')) // 漢数字
+            regexes.push(
+              match
+                .toString()
+                .replace(/(丁目?|番町|条|軒|線|(の|ノ)町|地割)/, ''),
+            ) // 漢数字
 
-          const num = match.replace(/([一二三四五六七八九十]+)/g, (match) => {
-            return kan2num(match)
-          }).replace(/(丁目?|番町|条|軒|線|(の|ノ)町|地割)/, '')
-          regexes.push(num.toString()) // 半角アラビア数字
-          regexes.push(String.fromCharCode(num.toString().charCodeAt(0) + 0xfee0)) // 全角アラビア数字
+            const num = match
+              .replace(/([一二三四五六七八九十]+)/g, (match) => {
+                return kan2num(match)
+              })
+              .replace(/(丁目?|番町|条|軒|線|(の|ノ)町|地割)/, '')
+            regexes.push(num.toString()) // 半角アラビア数字
+            regexes.push(
+              String.fromCharCode(num.toString().charCodeAt(0) + 0xfee0),
+            ) // 全角アラビア数字
 
-          // 以下の正規表現は、上のよく似た正規表現とは違うことに注意！
-          return `(${regexes.join('|')})(丁目?|番町|条|軒|線|の町?|地割|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])`
-        }),
+            // 以下の正規表現は、上のよく似た正規表現とは違うことに注意！
+            return `(${regexes.join(
+              '|',
+            )})(丁目?|番町|条|軒|線|の町?|地割|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])`
+          },
+        ),
     )
 
     if (city.match(/^京都市/)) {

--- a/test/addresses.test.ts
+++ b/test/addresses.test.ts
@@ -6,18 +6,16 @@ import path from 'path'
 const lines = fs.readFileSync(path.join(path.dirname(__filename), '/addresses.csv'), {encoding: 'utf-8'}).split(/\n/)
 lines.shift() // 見出し行
 
-for (let i = 0; i < lines.length; i++) {
-  if (! lines[i]) {
-    continue
+lines.forEach((line) => {
+  if (line) {
+    const data = line.trim().split(/,/)
+
+    test(data[0], async () => {
+      const res = await normalize(data[0])
+      expect(res.pref).toStrictEqual(data[1])
+      expect(res.city).toStrictEqual(data[2])
+      expect(res.town).toStrictEqual(data[3])
+      expect(res.addr).toStrictEqual(data[4])
+    })
   }
-
-  const data = lines[i].trim().split(/,/)
-
-  test(data[0], async () => {
-    const res = await normalize(data[0])
-    expect(res.pref).toStrictEqual(data[1])
-    expect(res.city).toStrictEqual(data[2])
-    expect(res.town).toStrictEqual(data[3])
-    expect(res.addr).toStrictEqual(data[4])
-  })
-}
+})

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -467,6 +467,11 @@ test('埼玉県上尾市一町目１１１', async () => {
   expect(res).toStrictEqual({"pref": "埼玉県", "city": "上尾市", "town": "壱丁目", "addr": "111"})
 })
 
+test('埼玉県上尾市壱町目１１１', async () => {
+  const res = await normalize('埼玉県上尾市壱町目１１１')
+  expect(res).toStrictEqual({"pref": "埼玉県", "city": "上尾市", "town": "壱丁目", "addr": "111"})
+})
+
 test('埼玉県上尾市1-111', async () => {
   const res = await normalize('埼玉県上尾市1-111')
   expect(res).toStrictEqual({"pref": "埼玉県", "city": "上尾市", "town": "壱丁目", "addr": "111"})

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -451,3 +451,23 @@ test('新潟県新潟市中央区上大川前通十一番町1881-2', async () =>
   const res = await normalize('新潟県新潟市中央区上大川前通十一番町1881-2')
   expect(res).toStrictEqual({"pref": "新潟県", "city": "新潟市中央区", "town": "上大川前通十一番町", "addr": "1881-2"})
 })
+
+test('埼玉県上尾市壱丁目１１１', async () => {
+  const res = await normalize('埼玉県上尾市壱丁目１１１')
+  expect(res).toStrictEqual({"pref": "埼玉県", "city": "上尾市", "town": "壱丁目", "addr": "111"})
+})
+
+test('埼玉県上尾市一丁目１１１', async () => {
+  const res = await normalize('埼玉県上尾市一丁目１１１')
+  expect(res).toStrictEqual({"pref": "埼玉県", "city": "上尾市", "town": "壱丁目", "addr": "111"})
+})
+
+test('埼玉県上尾市一町目１１１', async () => {
+  const res = await normalize('埼玉県上尾市一町目１１１')
+  expect(res).toStrictEqual({"pref": "埼玉県", "city": "上尾市", "town": "壱丁目", "addr": "111"})
+})
+
+test('埼玉県上尾市1-111', async () => {
+  const res = await normalize('埼玉県上尾市1-111')
+  expect(res).toStrictEqual({"pref": "埼玉県", "city": "上尾市", "town": "壱丁目", "addr": "111"})
+})

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -416,3 +416,38 @@ test('東京都新宿区三榮町１７－１６', async () => {
   const res = await normalize('東京都新宿区三榮町１７－１６')
   expect(res).toStrictEqual({"pref": "東京都", "city": "新宿区", "town": "四谷三栄町", "addr": "17-16"})
 })
+
+test('新潟県新潟市中央区礎町通１ノ町１９６８−１', async () => {
+  const res = await normalize('新潟県新潟市中央区礎町通１ノ町１９６８−１')
+  expect(res).toStrictEqual({"pref": "新潟県", "city": "新潟市中央区", "town": "礎町通一ノ町", "addr": "1968-1"})
+})
+
+test('新潟県新潟市中央区礎町通１の町１９６８−１', async () => {
+  const res = await normalize('新潟県新潟市中央区礎町通１の町１９６８−１')
+  expect(res).toStrictEqual({"pref": "新潟県", "city": "新潟市中央区", "town": "礎町通一ノ町", "addr": "1968-1"})
+})
+
+test('新潟県新潟市中央区礎町通１の町１９６８の１', async () => {
+  const res = await normalize('新潟県新潟市中央区礎町通１の町１９６８の１')
+  expect(res).toStrictEqual({"pref": "新潟県", "city": "新潟市中央区", "town": "礎町通一ノ町", "addr": "1968-1"})
+})
+
+test('新潟県新潟市中央区礎町通1-1968-1', async () => {
+  const res = await normalize('新潟県新潟市中央区礎町通1-1968-1')
+  expect(res).toStrictEqual({"pref": "新潟県", "city": "新潟市中央区", "town": "礎町通一ノ町", "addr": "1968-1"})
+})
+
+test('新潟県新潟市中央区上大川前通11番町1881-2', async () => {
+  const res = await normalize('新潟県新潟市中央区上大川前通11番町1881-2')
+  expect(res).toStrictEqual({"pref": "新潟県", "city": "新潟市中央区", "town": "上大川前通十一番町", "addr": "1881-2"})
+})
+
+test('新潟県新潟市中央区上大川前通11-1881-2', async () => {
+  const res = await normalize('新潟県新潟市中央区上大川前通11-1881-2')
+  expect(res).toStrictEqual({"pref": "新潟県", "city": "新潟市中央区", "town": "上大川前通十一番町", "addr": "1881-2"})
+})
+
+test('新潟県新潟市中央区上大川前通十一番町1881-2', async () => {
+  const res = await normalize('新潟県新潟市中央区上大川前通十一番町1881-2')
+  expect(res).toStrictEqual({"pref": "新潟県", "city": "新潟市中央区", "town": "上大川前通十一番町", "addr": "1881-2"})
+})


### PR DESCRIPTION
ホームズをみていると、`一ノ町` とか `十一番町` をアラビア数字で記述している事例が散見されるため、これらがアラビア数字で来ることを前提として正規化するように改善した。