### PR TITLE
住所の正規化をどの深さまで実行するかをnormalize()のオプション引数によって指定できるようにする

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,6 @@ const tmpdir = path.join(
 const fetch = require('node-fetch-cache')(tmpdir)
 import { toRegex } from './lib/dict'
 import NormalizationError from './lib/NormalizationError'
-import { formatWithOptions } from 'node:util'
 
 const endpoint = 'https://geolonia.github.io/japanese-addresses/api/ja'
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -481,3 +481,24 @@ test('神奈川県横浜市港北区大豆戸町１７番地１１', async () =>
   const res = await normalize('神奈川県横浜市港北区大豆戸町１７番地１１')
   expect(res).toStrictEqual({"pref": "神奈川県", "city": "横浜市港北区", "town": "大豆戸町", "addr": "17-11"})
 })
+
+test('神奈川県横浜市港北区大豆戸町１７番地１１', async () => {
+  const res = await normalize('神奈川県横浜市港北区大豆戸町１７番地１１', {
+    depth: 1
+  })
+  expect(res).toStrictEqual({ "pref": "神奈川県", "city": "", "town": "", "addr": "横浜市港北区大豆戸町１７番地１１" })
+})
+
+test('神奈川県横浜市港北区大豆戸町１７番地１１', async () => {
+  const res = await normalize('神奈川県横浜市港北区大豆戸町１７番地１１', {
+    depth: 2
+  })
+  expect(res).toStrictEqual({ "pref": "神奈川県", "city": "横浜市港北区", "town": "", "addr": "大豆戸町１７番地１１" })
+})
+
+test('神奈川県横浜市港北区大豆戸町１７番地１１', async () => {
+  const res = await normalize('神奈川県横浜市港北区大豆戸町１７番地１１', {
+    depth: 3
+  })
+  expect(res).toStrictEqual({ "pref": "神奈川県", "city": "横浜市港北区", "town": "大豆戸町", "addr": "17-11" })
+})


### PR DESCRIPTION
いつも使わせてもらっています。
気づかないうちにどんどん精度が向上していて、開発者の方々には頭が上がりません。ありがとうございます。  

この度は新機能の提案をさせていただきたくissueを建てさせてもらいました。  
僭越ながらプルリクを送らせていただきましたので、お手すきの際にご覧いただきご検討いただけますと幸甚です。

# 背景
- 大量の住所を含むCSVを読み込み、都道府県名、市区町村名などを抽出するプログラムを作成しています
- CSVの行数が大きい場合、処理にかかる時間が大きくなってしまいます
    - 都道府県名、市区町村名だけが必要な場合、町丁目以降の正規化に必要なgeolonia/japanese-addressesに対する新たなアクセスをキャンセルしたい
    - **用途に合わせてどこまで正規化するかを柔軟に指定できると嬉しい！**

# 提案内容
- `normalize()`に省略可能なオプション引数を用意し、どこまで正規化を行うかを柔軟に指定できるようにする
```javascript
test('神奈川県横浜市港北区大豆戸町１７番地１１', async () => {
  const res = await normalize('神奈川県横浜市港北区大豆戸町１７番地１１')
  expect(res).toStrictEqual({"pref": "神奈川県", "city": "横浜市港北区", "town": "大豆戸町", "addr": "17-11"})
})

test('神奈川県横浜市港北区大豆戸町１７番地１１', async () => {
  const res = await normalize('神奈川県横浜市港北区大豆戸町１７番地１１', {
    depth: 1
  })
  expect(res).toStrictEqual({ "pref": "神奈川県", "city": "", "town": "", "addr": "横浜市港北区大豆戸町１７番地１１" })
})

test('神奈川県横浜市港北区大豆戸町１７番地１１', async () => {
  const res = await normalize('神奈川県横浜市港北区大豆戸町１７番地１１', {
    depth: 2
  })
  expect(res).toStrictEqual({ "pref": "神奈川県", "city": "横浜市港北区", "town": "", "addr": "大豆戸町１７番地１１" })
})

test('神奈川県横浜市港北区大豆戸町１７番地１１', async () => {
  const res = await normalize('神奈川県横浜市港北区大豆戸町１７番地１１', {
    depth: 3
  })
  expect(res).toStrictEqual({ "pref": "神奈川県", "city": "横浜市港北区", "town": "大豆戸町", "addr": "17-11" })
})
```

# メリット・デメリット
- メリット
    - 市区町村名まででよい場合、処理速度が向上する
    - APIサーバーの負荷軽減
- デメリット
    - 関数が複雑になる