### PR TITLE
ts-jestに関するwarningに対する修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     },
     "globals": {
       "ts-jest": {
-        "tsConfig": "tsconfig.json"
+        "tsconfig": "tsconfig.json"
       }
     }
   },


### PR DESCRIPTION
`npm run test`を実行したら次のエラーが出たので`package.json`を修正しました。

```
ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead
```