### PR TITLE
「和歌山県」を「和歌山」のように「都道府県」の文字列を入れないケースに対応

### DIFF
--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -36,7 +36,7 @@ export const getPrefectureRegexes = (prefs: string[]) => {
 
   cachedPrefectureRegexes = prefs.map((pref) => {
     const _pref = pref.replace(/(都|道|府|県)$/, '') // `東京` の様に末尾の `都府県` が抜けた住所に対応
-    const reg = new RegExp(`^${_pref}(都|道|府|県)`)
+    const reg = new RegExp(`^${_pref}(都|道|府|県)?`)
     return [pref, reg]
   })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,9 +91,10 @@ export const normalize: (
 
   for (let i = 0; i < prefRegexes.length; i++) {
     const [_pref, reg] = prefRegexes[i]
-    if (addr.match(reg)) {
+    const match = addr.match(reg)
+    if (match) {
       pref = _pref
-      addr = addr.substring(pref.length) // 都道府県名以降の住所
+      addr = addr.substring(match[0].length) // 都道府県名以降の住所
       break
     }
   }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -726,3 +726,9 @@ test('岩手県花巻市１２丁目７０４', async () => {
   const res = await normalize('岩手県花巻市１２丁目７０４')
   expect(res).toStrictEqual({"pref": "岩手県", "city": "花巻市", "town": "十二丁目", "addr": "704", "lat": 39.358268, "lng": 141.122331, "level": 3})
 })
+
+// 「都道府県」の文字列を省略した場合
+test('岩手花巻市１２丁目７０４', async () => {
+  const res = await normalize('岩手花巻市１２丁目７０４')
+  expect(res).toStrictEqual({"pref": "岩手県", "city": "花巻市", "town": "十二丁目", "addr": "704", "lat": 39.358268, "lng": 141.122331, "level": 3})
+})


### PR DESCRIPTION
community-geocoder の

「和歌山県」を「和歌山」のように「都道府県」の文字列を入れないケースに対応
https://github.com/geolonia/community-geocoder/issues/88

は、正規化する時点で対応したほうが良いと思うので、こちらに PR を作成しました。
