### PR TITLE
入力パラメタが、都道府県・市区町村のみであった場合の normalize 処理を、代表地点を採用して返却するように修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ const defaultOption: Option = {
 
 /**
  * pref city を元に、町丁目リストを取得し、addr に match する町丁目JSON値を返却する
- * addr が pref + city に完全一致する場合、getTowns で得られる最初のエントリを代表番地と仮定して返却する
+ * addr が empty の場合、getTowns で得られる最初のエントリを代表地点と仮定して返却する
  *
  * @param addr 町丁目文字列
  * @param pref 都道府県文字列
@@ -60,6 +60,7 @@ const normalizeTownName = async (addr: string, pref: string, city: string) => {
               lng: _town.lng,
             }
           case 1:
+            // 2度目の処理のため、地点のみ返却
             return {
               town: '',
               addr: '',
@@ -70,7 +71,7 @@ const normalizeTownName = async (addr: string, pref: string, city: string) => {
       }
     }
 
-    // addr が pref + city に完全一致する場合、getTowns で得られる最初のエントリを代表番地と仮定して返却する
+    // addr が empty の場合、getTowns で得られる最初のエントリを代表地点と仮定して返却するため、再度処理を促す
     if (_addr) {
       return
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,11 +51,21 @@ const normalizeTownName = async (addr: string, pref: string, city: string) => {
       const match = _addr.match(reg)
 
       if (match) {
-        return {
-          town: _town.town,
-          addr: _addr.substr(match[0].length),
-          lat: _town.lat,
-          lng: _town.lng,
+        switch (tryCount) {
+          case 0:
+            return {
+              town: _town.town,
+              addr: _addr.substr(match[0].length),
+              lat: _town.lat,
+              lng: _town.lng,
+            }
+          case 1:
+            return {
+              town: '',
+              addr: '',
+              lat: _town.lat,
+              lng: _town.lng,
+            }
         }
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ const normalizeTownName = async (addr: string, pref: string, city: string) => {
       break;
     }
     if(recursiveParamAddr){
-      return await normalizeTownName(recursiveParamAddr.town, pref, city);
+      return await normalizeTownName(`${pref}${city}${recursiveParamAddr.town}`, pref, city);
     }
   }
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -751,5 +751,5 @@ test('岩手花巻市１２丁目７０４', async () => {
 test('It should get the level `3` with `埼玉県熊谷市` because town is null', async () => {
   const res = await normalize('埼玉県熊谷市')
   const expectTown = await getTowns("埼玉県", "熊谷市")
-  expect(res).toStrictEqual({"pref": "埼玉県", "city": "熊谷市", "town": expectTown[0].town, "addr": "", "lat": expectTown[0].lat, "lng": expectTown[0].lng, "level": 3})
+  expect(res).toStrictEqual({"pref": "埼玉県", "city": "熊谷市", "town": "", "addr": "", "lat": expectTown[0].lat, "lng": expectTown[0].lng, "level": 2})
 })

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,3 +1,4 @@
+import { getTowns } from '../src/lib/cacheRegexes'
 import { normalize } from '../src/main'
 
 test('大阪府堺市北区新金岡町4丁1−8', async () => {
@@ -488,13 +489,6 @@ test('It should get the level `3` with `神奈川県横浜市港北区大豆戸�
   expect(res).toStrictEqual({ "pref": "神奈川県", "city": "横浜市港北区", "town": "大豆戸町", "addr": "17-11", "lat": 35.513492, "lng": 139.625651, "level": 3})
 })
 
-test('It should get the level `2` with `神奈川県横浜市港北区`', async () => {
-  const res = await normalize('神奈川県横浜市港北区', {
-    level: 3
-  })
-  expect(res).toStrictEqual({ "pref": "神奈川県", "city": "横浜市港北区", "town": "", "addr": "", "lat": null, "lng": null, "level": 2})
-})
-
 test('It should get the level `1` with `神奈川県`', async () => {
   const res = await normalize('神奈川県', {
     level: 3
@@ -746,9 +740,16 @@ test('京都府宇治市莵道森本8−10（莵と菟のゆらぎ）', async ()
   const res = await normalize('京都府宇治市菟道森本8−10')
   expect(res).toStrictEqual({"pref": "京都府", "city": "宇治市", "town": "莵道", "addr": "森本8-10", "level": 3, "lat": 34.904244, "lng": 135.827041})
 })
-  
+
 // 「都道府県」の文字列を省略した場合
 test('岩手花巻市１２丁目７０４', async () => {
   const res = await normalize('岩手花巻市１２丁目７０４')
   expect(res).toStrictEqual({"pref": "岩手県", "city": "花巻市", "town": "十二丁目", "addr": "704", "lat": 39.358268, "lng": 141.122331, "level": 3})
+})
+
+// パラメタが都道府県・市区町村のみであった場合
+test('It should get the level `3` with `埼玉県熊谷市` because town is null', async () => {
+  const res = await normalize('埼玉県熊谷市')
+  const expectTown = await getTowns("埼玉県", "熊谷市")
+  expect(res).toStrictEqual({"pref": "埼玉県", "city": "熊谷市", "town": expectTown[0].town, "addr": "", "lat": expectTown[0].lat, "lng": expectTown[0].lng, "level": 3})
 })

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -748,7 +748,7 @@ test('岩手花巻市１２丁目７０４', async () => {
 })
 
 // パラメタが都道府県・市区町村のみであった場合
-test('It should get the level `3` with `埼玉県熊谷市` because town is null', async () => {
+test('It should get the level `2` with `埼玉県熊谷市` because town is null', async () => {
   const res = await normalize('埼玉県熊谷市')
   const expectTown = await getTowns("埼玉県", "熊谷市")
   expect(res).toStrictEqual({"pref": "埼玉県", "city": "熊谷市", "town": "", "addr": "", "lat": expectTown[0].lat, "lng": expectTown[0].lng, "level": 2})


### PR DESCRIPTION
https://github.com/geolonia/community-geocoder/issues/124

これに対応するため、乱暴な仕様ではありますが、提案ベースでプルリクエストを作成しました。

ご検討よろしくお願いします。

### 代表地点とは
getTowns(x, x)[0]　であり、決して IMI の挙動と一致させているわけではありません。
https://github.com/geolonia/community-geocoder#%E4%BB%95%E7%B5%84%E3%81%BF
に記載の仕様に合致しない現状回避の暫定措置程度でお考えいただければと思います。
