### PR TITLE
Explicit type reference, npm package cleanup

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 /cache
-src/addresses/test.*
+/.github
+/src/addresses/test.*
+/test

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "browser": "./dist/main.js",
   "main": "./dist/main-node.js",
+  "types": "./dist/main.d.ts",
   "scripts": {
     "test": "npm run test:main && npm run test:addresses",
     "test:main": "jest test/main.test.ts",


### PR DESCRIPTION
* package.json の `types` を指定しないと main-node.js のエントリポイントを使う時にtypescriptがtype definitionを拾ってくれなかったので、追加しました。
* `test` 内のテスト用ファイルが1MBぐらい入っていたのでパッケージサイス節約。