### PR TITLE
茨城県猿島郡境町大字なしの住所に対応

### DIFF
--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -143,6 +143,11 @@ export const getTownRegexes = async (pref: string, city: string) => {
         ),
     )
 
+    // 「茨城県猿島郡境町391番地1」のような大字なしの住所に対応
+    if (pref === '茨城県' && city === '猿島郡境町' && town.town === '（大字なし）') {
+      return [town, /^\d+番地/]
+    }
+
     if (city.match(/^京都市/)) {
       return [town, new RegExp(`.*${regex}`)]
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,9 +40,12 @@ const normalizeTownName = async (addr: string, pref: string, city: string) => {
     const match = addr.match(reg)
 
     if (match) {
+      if (_town.town !== '（大字なし）') {
+        addr = addr.substr(match[0].length)
+      }
       return {
         town: _town.town,
-        addr: addr.substr(match[0].length),
+        addr: addr,
         lat: _town.lat,
         lng: _town.lng,
       }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -757,3 +757,8 @@ test('千葉県巿川巿巿川1丁目（市(し、いち)と巿(ふつ)のゆら
   const res = await normalize('千葉県巿川巿巿川1丁目')
   expect(res).toStrictEqual({"pref": "千葉県", "city": "市川市", "town": "市川一丁目", "addr": "", "level": 3, "lat": 35.731849, "lng": 139.909029})
 })
+
+test('茨城県猿島郡境町391番地1（茨城県猿島郡境町の大字なしの住所）', async () => {
+  const res = await normalize('茨城県猿島郡境町391番地1')
+  expect(res).toStrictEqual({"pref": "茨城県", "city": "猿島郡境町", "town": "（大字なし）", "addr": "391-1", "level": 3, "lat": 36.100302, "lng": 139.79574})
+})


### PR DESCRIPTION
https://github.com/geolonia/community-geocoder/issues/101 を解決するための PR です。