### PR TITLE
キャッシュの有効期限を意図したものに変更

### DIFF
--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -15,7 +15,7 @@ export type TownList = SingleTown[]
 
 export const cachedTownRegexes = new LRU<string, [SingleTown, string][]>({
   max: currentConfig.townCacheSize,
-  maxAge: 60 * 60 * 24 * 7, // 7日間
+  maxAge: 60 * 60 * 24 * 7 * 1000, // 7日間
 })
 
 let cachedPrefecturePatterns: [string, string][] | undefined = undefined

--- a/src/main-node.ts
+++ b/src/main-node.ts
@@ -24,6 +24,7 @@ export const preload = async () => {
   }
 
   cachedTownRegexes.max = Infinity
+  cachedTownRegexes.maxAge = Infinity
   let zipBuffer: Buffer
 
   // file:// でローカルにダウンロードした zip ファイルを参照する。


### PR DESCRIPTION
大量に処理していて 7日 / 1000 ≒ 10分 でキャッシュがなくなっていたので気づきました。
プリロード時は maxAge は無限に設定しました。