### PR TITLE
Aggregate ○○町 pattern

### DIFF
--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -128,7 +128,7 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
     ...townsWithCho.map((town) => ({
       ...town,
       originalTown: town.town,
-      town: town.town.replace(/町$/, ''),
+      town: town.town.replace(/町/g, ''),
     })),
   )
 

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -92,12 +92,14 @@ export const getTowns = async (pref: string, city: string) => {
 }
 
 // 同じ自治体の中に「◯◯町」と「○○」が共存しているか
-export const coexistTownNameEndWithCho = (
+export const coexistTownNameWithChoCharcter = (
   targetTownName: string,
   towns: TownList,
 ) => {
   for (let i = 0; i < towns.length; i++) {
     const townName = towns[i].town
+    // ◯◯町 （町で終わる）パターンと、 ◯◯町△△ のパターンの両方がある
+    // どちらのケースにも対応する
     if (townName.indexOf('町') === -1) continue
     if (targetTownName.replace(/町/g, '') === townName) {
       return true
@@ -119,7 +121,8 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
   // この場合は町の省略は許容せず、住所は書き分けられているものとして正規化を行う。
   const townsEndWithCho = towns.filter(
     (town) =>
-      town.town.endsWith('町') && !coexistTownNameEndWithCho(town.town, towns),
+      town.town.endsWith('町') &&
+      !coexistTownNameWithChoCharcter(town.town, towns),
   )
   towns.push(
     ...townsEndWithCho.map((town) => ({

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -7,6 +7,7 @@ import { __internals } from '../normalize'
 type PrefectureList = { [key: string]: string[] }
 interface SingleTown {
   town: string
+  originalTown?: string
   koaza: string
   lat: string
   lng: string
@@ -97,6 +98,16 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
   }
 
   const towns = await getTowns(pref, city)
+
+  // 町丁目が「町」で終わるケースへの対応
+  const townsEndWithCho = towns.filter((town) => town.town.endsWith('町'))
+  towns.push(
+    ...townsEndWithCho.map((town) => ({
+      ...town,
+      originalTown: town.town,
+      town: town.town.replace(/町$/, ''),
+    })),
+  )
 
   // 少ない文字数の地名に対してミスマッチしないように文字の長さ順にソート
   towns.sort((a, b) => {

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -116,16 +116,16 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
 
   const towns = await getTowns(pref, city)
 
-  // 町丁目が「町」で終わるケースへの対応
-  // 通常は「○○町」のうち「町」の省略は許容し、同義語として扱うが、まれに自治体内に「○○町」と「○○」が共存しているケースがある。
-  // この場合は町の省略は許容せず、住所は書き分けられているものとして正規化を行う。
-  const townsEndWithCho = towns.filter(
+  // 町丁目に「町」が含まれるケースへの対応
+  // 通常は「○○町」のうち「町」の省略を許容し同義語として扱うが、まれに自治体内に「○○町」と「○○」が共存しているケースがある。
+  // この場合は町の省略は許容せず、入力された住所は書き分けられているものとして正規化を行う。
+  const townsWithCho = towns.filter(
     (town) =>
-      town.town.endsWith('町') &&
+      town.town.indexOf('町') !== -1 &&
       !coexistTownNameWithChoCharcter(town.town, towns),
   )
   towns.push(
-    ...townsEndWithCho.map((town) => ({
+    ...townsWithCho.map((town) => ({
       ...town,
       originalTown: town.town,
       town: town.town.replace(/町$/, ''),

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -92,14 +92,14 @@ export const getTowns = async (pref: string, city: string) => {
 }
 
 // 同じ自治体の中に「◯◯町」と「○○」が共存しているか
-export const coExistTownNameEndWithCho = (
+export const coexistTownNameEndWithCho = (
   targetTownName: string,
   towns: TownList,
 ) => {
   for (let i = 0; i < towns.length; i++) {
     const townName = towns[i].town
-    if (townName.endsWith('町')) continue
-    if (targetTownName.replace(/町$/, '') === townName) {
+    if (townName.indexOf('町') === -1) continue
+    if (targetTownName.replace(/町/g, '') === townName) {
       return true
     }
   }
@@ -119,7 +119,7 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
   // この場合は町の省略は許容せず、住所は書き分けられているものとして正規化を行う。
   const townsEndWithCho = towns.filter(
     (town) =>
-      town.town.endsWith('町') && !coExistTownNameEndWithCho(town.town, towns),
+      town.town.endsWith('町') && !coexistTownNameEndWithCho(town.town, towns),
   )
   towns.push(
     ...townsEndWithCho.map((town) => ({

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -89,7 +89,6 @@ const normalizeTownName = async (addr: string, pref: string, city: string) => {
   for (let i = 0; i < townPatterns.length; i++) {
     const [_town, pattern] = townPatterns[i]
     const match = addr.match(pattern)
-
     if (match) {
       return {
         town: _town.originalTown || _town.town,

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -92,7 +92,7 @@ const normalizeTownName = async (addr: string, pref: string, city: string) => {
 
     if (match) {
       return {
-        town: _town.town,
+        town: _town.originalTown || _town.town,
         addr: addr.substr(match[0].length),
         lat: _town.lat,
         lng: _town.lng,

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -877,6 +877,12 @@ for (const [runtime, normalize] of cases) {
           expect(res).toStrictEqual({"pref": "広島県", "city": "三原市", "town": "幸崎町久和喜", "addr": "789-1234", "level": 3, "lat": 34.352656, "lng": 133.055612})
         })
       })
+
+      // 漢数字を含む町丁目については、後続の丁目や番地が壊れるので町の省略を許容しない
+      test('愛知県名古屋市瑞穂区十六町１丁目123-4', async () => {
+        const res = await normalize('愛知県名古屋市瑞穂区十六町１丁目123-4')
+        expect(res).toStrictEqual({"pref": "愛知県", "city": "名古屋市瑞穂区", "town": "十六町一丁目", "addr": "123-4", "level": 3, "lat": 35.128862, "lng":  136.936585})
+      })
     })
   })
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -835,15 +835,20 @@ for (const [runtime, normalize] of cases) {
       expect(res).toStrictEqual({"pref": "埼玉県", "city": "川口市", "town": "大字芝", "addr": "字宮根3938-5", "level": 3, "lat": 35.843399, "lng": 139.690803})
     })
 
-    test('北海道上川郡東神楽町14号北1番地',  async () => {
+    test('北海道上川郡東神楽町14号北1番地', async () => {
       const res = await normalize('北海道上川郡東神楽町14号北1番地')
       expect(res).toStrictEqual({"pref": "北海道", "city": "上川郡東神楽町", "town": "十四号", "addr": "北1", "level": 3, "lat": 43.693918, "lng": 142.463511})
     })
 
-    test('北海道上川郡東神楽町十四号北1番地',  async () => {
+    test('北海道上川郡東神楽町十四号北1番地', async () => {
       const res = await normalize('北海道上川郡東神楽町十四号北1番地')
       expect(res).toStrictEqual({"pref": "北海道", "city": "上川郡東神楽町", "town": "十四号", "addr": "北1", "level": 3, "lat": 43.693918, "lng": 142.463511})
     })
 
+      // 町丁目の末尾の町を省略したケース
+      test('東京都江戸川区西小松川12-345', async () => {
+      const res = await normalize('東京都江戸川区西小松川12-345')
+      expect(res).toStrictEqual({"pref": "東京都", "city": "江戸川区", "town": "西小松川町", "addr": "12-345", "level": 3, "lat": 35.698405, "lng": 139.862007})
+    })
   })
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -851,7 +851,7 @@ for (const [runtime, normalize] of cases) {
         expect(res).toStrictEqual({"pref": "東京都", "city": "江戸川区", "town": "西小松川町", "addr": "12-345", "level": 3, "lat": 35.698405, "lng": 139.862007})
       })
 
-      describe('自治体内に町あり/なしで同じ名前の町丁目が共存している', () => {
+      describe('自治体内に町あり/なしが違うだけでほぼ同じ名前の町丁目が共存しているケース', () => {
         test('福島県須賀川市西川町123-456', async () => {
           const res = await normalize('福島県須賀川市西川町123-456')
           expect(res).toStrictEqual({"pref": "福島県", "city": "須賀川市", "town": "西川町", "addr": "123-456", "level": 3, "lat": 37.294611, "lng": 140.359974})
@@ -860,6 +860,16 @@ for (const [runtime, normalize] of cases) {
         test('福島県須賀川市西川123-456', async () => {
           const res = await normalize('福島県須賀川市西川123-456')
           expect(res).toStrictEqual({"pref": "福島県", "city": "須賀川市", "town": "西川", "addr": "123-456", "level": 3, "lat": 37.296938, "lng": 140.343569})
+        })
+
+        test('広島県三原市幸崎久和喜789-1234', async () => {
+          const res = await normalize('広島県三原市幸崎久和喜789-1234')
+          expect(res).toStrictEqual({"pref": "広島県", "city": "三原市", "town": "幸崎久和喜", "addr": "789-1234", "level": 3, "lat": 34.348481, "lng": 133.067756})
+        })
+
+        test('広島県三原市幸崎町久和喜789-1234', async () => {
+          const res = await normalize('広島県三原市幸崎町久和喜789-1234')
+          expect(res).toStrictEqual({"pref": "広島県", "city": "三原市", "town": "幸崎町久和喜", "addr": "789-1234", "level": 3, "lat": 34.352656, "lng": 133.055612})
         })
       })
     })

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -867,14 +867,14 @@ for (const [runtime, normalize] of cases) {
           expect(res).toStrictEqual({"pref": "福島県", "city": "須賀川市", "town": "西川", "addr": "123-456", "level": 3, "lat": 37.296938, "lng": 140.343569})
         })
 
-        test('広島県三原市幸崎久和喜789-1234', async () => {
-          const res = await normalize('広島県三原市幸崎久和喜789-1234')
-          expect(res).toStrictEqual({"pref": "広島県", "city": "三原市", "town": "幸崎久和喜", "addr": "789-1234", "level": 3, "lat": 34.348481, "lng": 133.067756})
+        test('広島県三原市幸崎久和喜12-345', async () => {
+          const res = await normalize('広島県三原市幸崎久和喜12-345')
+          expect(res).toStrictEqual({"pref": "広島県", "city": "三原市", "town": "幸崎久和喜", "addr": "12-345", "level": 3, "lat": 34.348481, "lng": 133.067756})
         })
 
-        test('広島県三原市幸崎町久和喜789-1234', async () => {
-          const res = await normalize('広島県三原市幸崎町久和喜789-1234')
-          expect(res).toStrictEqual({"pref": "広島県", "city": "三原市", "town": "幸崎町久和喜", "addr": "789-1234", "level": 3, "lat": 34.352656, "lng": 133.055612})
+        test('広島県三原市幸崎町久和喜24-56', async () => {
+          const res = await normalize('広島県三原市幸崎町久和喜24-56')
+          expect(res).toStrictEqual({"pref": "広島県", "city": "三原市", "town": "幸崎町久和喜", "addr": "24-56", "level": 3, "lat": 34.352656, "lng": 133.055612})
         })
       })
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -845,10 +845,15 @@ for (const [runtime, normalize] of cases) {
       expect(res).toStrictEqual({"pref": "北海道", "city": "上川郡東神楽町", "town": "十四号", "addr": "北1", "level": 3, "lat": 43.693918, "lng": 142.463511})
     })
 
-    describe('町丁目の末尾の町の省略に関連するケース', () => {
+    describe('町丁目内の文字列の「町」の省略に関連するケース', () => {
       test('東京都江戸川区西小松川12-345', async () => {
         const res = await normalize('東京都江戸川区西小松川12-345')
         expect(res).toStrictEqual({"pref": "東京都", "city": "江戸川区", "town": "西小松川町", "addr": "12-345", "level": 3, "lat": 35.698405, "lng": 139.862007})
+      })
+
+      test('滋賀県長浜市木之本西山123-4', async () => {
+        const res = await normalize('滋賀県長浜市木之本西山123-4')
+        expect(res).toStrictEqual({"pref": "滋賀県", "city": "長浜市", "town": "木之本町西山", "addr": "123-4", "level": 3, "lat": 35.496171, "lng": 136.204177})
       })
 
       describe('自治体内に町あり/なしが違うだけでほぼ同じ名前の町丁目が共存しているケース', () => {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -845,10 +845,23 @@ for (const [runtime, normalize] of cases) {
       expect(res).toStrictEqual({"pref": "北海道", "city": "上川郡東神楽町", "town": "十四号", "addr": "北1", "level": 3, "lat": 43.693918, "lng": 142.463511})
     })
 
-      // 町丁目の末尾の町を省略したケース
+    describe('町丁目の末尾の町の省略に関連するケース', () => {
       test('東京都江戸川区西小松川12-345', async () => {
-      const res = await normalize('東京都江戸川区西小松川12-345')
-      expect(res).toStrictEqual({"pref": "東京都", "city": "江戸川区", "town": "西小松川町", "addr": "12-345", "level": 3, "lat": 35.698405, "lng": 139.862007})
+        const res = await normalize('東京都江戸川区西小松川12-345')
+        expect(res).toStrictEqual({"pref": "東京都", "city": "江戸川区", "town": "西小松川町", "addr": "12-345", "level": 3, "lat": 35.698405, "lng": 139.862007})
+      })
+
+      describe('自治体内に町あり/なしで同じ名前の町丁目が共存している', () => {
+        test('福島県須賀川市西川町123-456', async () => {
+          const res = await normalize('福島県須賀川市西川町123-456')
+          expect(res).toStrictEqual({"pref": "福島県", "city": "須賀川市", "town": "西川町", "addr": "123-456", "level": 3, "lat": 37.294611, "lng": 140.359974})
+        })
+
+        test('福島県須賀川市西川123-456', async () => {
+          const res = await normalize('福島県須賀川市西川123-456')
+          expect(res).toStrictEqual({"pref": "福島県", "city": "須賀川市", "town": "西川", "addr": "123-456", "level": 3, "lat": 37.296938, "lng": 140.343569})
+        })
+      })
     })
   })
 }


### PR DESCRIPTION
町丁目が町で終わるパターンへの対応。「○○町」の町が省略されていたとしても正規化する。