### PR TITLE
京都の通り名削除の際に「◯号室」が「◯丁目」と正規化されるケースへの対応

### DIFF
--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -182,7 +182,7 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
             // 以下の正規表現は、上のよく似た正規表現とは違うことに注意！
             const _pattern = `(${patterns.join(
               '|',
-              // 通り名削除の際に「◯丁目」と「◯号室」がコンフリクトしないように `号(?!室)` という記述がされている。
+              // 「◯丁目」と「◯号室」がコンフリクトしないように `号(?!室)` という記述がされている。
               // このパターンは今後他のコンフリクトのケースが見つかった時に増えるかもしれない。
               // 次の issue を参照: https://github.com/geolonia/normalize-japanese-addresses/issues/162
             )})((丁|町)目?|番(町|丁)|条|軒|線|の町?|地割|号(?!室)|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])`

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -182,7 +182,10 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
             // 以下の正規表現は、上のよく似た正規表現とは違うことに注意！
             const _pattern = `(${patterns.join(
               '|',
-            )})((丁|町)目?|番(町|丁)|条|軒|線|の町?|地割|号|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])`
+              // 通り名削除の際に「◯丁目」と「◯号室」がコンフリクトしないように `号(?!室)` という記述がされている。
+              // このパターンは今後他のコンフリクトのケースが見つかった時に増えるかもしれない。
+              // 次の issue を参照: https://github.com/geolonia/normalize-japanese-addresses/issues/162
+            )})((丁|町)目?|番(町|丁)|条|軒|線|の町?|地割|号(?!室)|[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━])`
 
             return _pattern // デバッグのときにめんどくさいので変数に入れる。
           },

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -190,6 +190,7 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
     )
 
     if (city.match(/^京都市/)) {
+      // 通り名を削除する
       return [town, `.*${pattern}`]
     } else {
       return [town, `^${pattern}`]

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -924,5 +924,11 @@ for (const [runtime, normalize] of cases) {
         expect(res).toStrictEqual({"pref": "石川県", "city": "輪島市", "town": "町野町桶戸", "addr": "", "level": 3, "lat": 37.414993, "lng":  137.092547})
       })
     })
+
+    // 建物名と京都の通り名削除がコンフリクトしないようにする
+    test.only('京都府京都市中京区山本町９９９番地おはようビル２０５号室', async () => {
+      const res = await normalize('京都府京都市中京区山本町９９９番地おはようビル２０５号室')
+      expect(res).toStrictEqual({"pref": "京都府", "city": "京都市中京区", "town": "山本町", "addr": "９９９番地おはようビル２０５号室", "level": 3, "lat": -1, "lng": -1})
+    })
   })
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -5,7 +5,7 @@ import { normalize as normalizerForBrowser } from '../src/main-browser'
 
 const cases: [runtime: string, normalizer: typeof normalizerForNode | typeof normalizerForBrowser][] = [
   ['node', normalizerForNode],
-  // ['browser', normalizerForBrowser],
+  ['browser', normalizerForBrowser],
 ]
 
 for (const [runtime, normalize] of cases) {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -934,7 +934,7 @@ for (const [runtime, normalize] of cases) {
       expect(resp.city).toEqual('つくば市')
     })
 
-    // 建物名に「号室」が使われていた時に、京都の通り名削除とコンフリクトしないようにする
+    // このケースは、中京区五丁目という町丁目がり、これに意図せずマッチしないことをテストしている
     test('京都府京都市中京区山本町９９９番地おはようビル２０５号室', async () => {
       const res = await normalize('京都府京都市中京区山本町９９９番地おはようビル２０５号室')
       expect(res).toStrictEqual({"pref": "京都府", "city": "京都市中京区", "town": "山本町", "addr": "999おはようビル205号室", "level": 3, "lat": 35.012883, "lng": 135.766495})

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -3,7 +3,10 @@
 import { normalize as normalizerForNode } from '../src/main-node'
 import { normalize as normalizerForBrowser } from '../src/main-browser'
 
-const cases: [runtime: string, normalizer: typeof normalizerForNode | typeof normalizerForBrowser][] = [['node', normalizerForNode], ['browser', normalizerForBrowser]]
+const cases: [runtime: string, normalizer: typeof normalizerForNode | typeof normalizerForBrowser][] = [
+  ['node', normalizerForNode],
+  // ['browser', normalizerForBrowser],
+]
 
 for (const [runtime, normalize] of cases) {
   describe(`tests for ${runtime} entry point`, () => {
@@ -931,10 +934,10 @@ for (const [runtime, normalize] of cases) {
       expect(resp.city).toEqual('つくば市')
     })
 
-    // 建物名と京都の通り名削除がコンフリクトしないようにする
-    test.only('京都府京都市中京区山本町９９９番地おはようビル２０５号室', async () => {
+    // 建物名に「号室」が使われていた時に、京都の通り名削除とコンフリクトしないようにする
+    test('京都府京都市中京区山本町９９９番地おはようビル２０５号室', async () => {
       const res = await normalize('京都府京都市中京区山本町９９９番地おはようビル２０５号室')
-      expect(res).toStrictEqual({"pref": "京都府", "city": "京都市中京区", "town": "山本町", "addr": "９９９番地おはようビル２０５号室", "level": 3, "lat": -1, "lng": -1})
+      expect(res).toStrictEqual({"pref": "京都府", "city": "京都市中京区", "town": "山本町", "addr": "999おはようビル205号室", "level": 3, "lat": 35.012883, "lng": 135.766495})
     })
   })
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -934,10 +934,13 @@ for (const [runtime, normalize] of cases) {
       expect(resp.city).toEqual('つくば市')
     })
 
-    // このケースは、中京区五丁目という町丁目がり、これに意図せずマッチしないことをテストしている
+    // 中京区五丁目という町丁目があり、これに意図せずマッチしないことをテストしている
     test('京都府京都市中京区山本町９９９番地おはようビル２０５号室', async () => {
       const res = await normalize('京都府京都市中京区山本町９９９番地おはようビル２０５号室')
-      expect(res).toStrictEqual({"pref": "京都府", "city": "京都市中京区", "town": "山本町", "addr": "999おはようビル205号室", "level": 3, "lat": 35.012883, "lng": 135.766495})
+      expect(res.city).toEqual('京都市中京区')
+      expect(res.town).not.toEqual('五丁目')
+      expect(res.town).toEqual('山本町')
+      expect(res.addr).toEqual('999おはようビル205号室')
     })
   })
 }


### PR DESCRIPTION
京都で建物名に `号`  が含まれる場合、通り名削除と丁目・番地・号の正規化がコンフリクトしているのが #157 のケースです。
建物名としてよくある `号室` を、丁目・番地・号の正規化パターンから除外するのが最も効率的と考えました。

同様のパターンで予期しない建物名により正規化が失敗するケースが今後出現すると思われますが、都度同じように対応することでしばらくはそこまでコードの複雑さを増やさずに改善を続けられると考えています。
