### PR TITLE
京都市内に対しては町の省略は許容しない

### DIFF
--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -110,6 +110,8 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
   const townSet = new Set(pre_towns.map((town) => town.town))
   const towns = []
 
+  const isKyoto = city.match(/^京都市/)
+
   // 町丁目に「○○町」が含まれるケースへの対応
   // 通常は「○○町」のうち「町」の省略を許容し同義語として扱うが、まれに自治体内に「○○町」と「○○」が共存しているケースがある。
   // この場合は町の省略は許容せず、入力された住所は書き分けられているものとして正規化を行う。
@@ -121,6 +123,7 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
     if (originalTown.indexOf('町') === -1) continue
     const townAbbr = originalTown.replace(/(?!^町)町/g, '') // NOTE: 冒頭の「町」は明らかに省略するべきではないので、除外
     if (
+      !isKyoto && // 京都は通り名削除の処理があるため、意図しないマッチになるケースがある。これを除く
       !townSet.has(townAbbr) &&
       !townSet.has(`大字${townAbbr}`) && // 大字は省略されるため、大字〇〇と〇〇町がコンフリクトする。このケースを除外
       !isKanjiNumberFollewedByCho(originalTown)
@@ -189,7 +192,7 @@ export const getTownRegexPatterns = async (pref: string, city: string) => {
         ),
     )
 
-    if (city.match(/^京都市/)) {
+    if (isKyoto) {
       return [town, `.*${pattern}`]
     } else {
       return [town, `^${pattern}`]

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -923,6 +923,13 @@ for (const [runtime, normalize] of cases) {
         const res = await normalize('石川県輪島市町野桶戸')
         expect(res).toStrictEqual({"pref": "石川県", "city": "輪島市", "town": "町野町桶戸", "addr": "", "level": 3, "lat": 37.414993, "lng":  137.092547})
       })
+
+      test('京都府京都市下京区西中筋通北小路通上る丸屋町 京都の通り名削除と町の省略がコンフリクトするケース', async () => {
+        const res = await normalize('京都府京都市下京区西中筋通北小路通上る丸屋町')
+        expect(res.city).toEqual('京都市下京区')
+        expect(res.town).not.toEqual('北小路町')
+        expect(res.town).toEqual('丸屋町')
+      })
     })
 
     test('should handle unicode normalization', async () => {


### PR DESCRIPTION
通り名削除と競合するケース #162 があるため。
例えば `京都市下京区西中筋通北小路通上る丸屋町` は、`京都市下京区丸屋町` にヒットするのが正しいが、`京都市下京区北小路町` も存在するため、`京都市下京区北小路` のように省略されているケースと競合してしまう。

京都については「町」の省略は許容しないように修正。