### PR TITLE
japanese addresses側でlatとlngのデータを持っていない場合はNaNでなくnullを返す。

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -256,8 +256,8 @@ export const normalize: Normalizer = async (
     if (normalized) {
       town = normalized.town
       addr = normalized.addr
-      lat = parseFloat(normalized.lat)
-      lng = parseFloat(normalized.lng)
+      lat = normalized.lat ? parseFloat(normalized.lat) : null
+      lng = normalized.lng ? parseFloat(normalized.lng) : null
     }
 
     addr = (banchiGoQueue.join('') + addr)

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -999,5 +999,11 @@ for (const [runtime, normalize] of cases) {
       const resp = await normalize(address)
       expect(resp.city).toEqual('つくば市')
     })
+
+    test('latとlngのデータがない場合はnullを返す', async () => {
+      const res = await normalize('大分県大分市田中町3丁目1-12')
+      expect(res.lat).toEqual(null)
+      expect(res.lng).toEqual(null)
+    })
   })
 }


### PR DESCRIPTION
https://github.com/geolonia/japanese-addresses/issues/93 を調査していたときに発見したバグ。

japanese addresses側でlatとlngのデータを持っていない場合はNaNでなくnullを返すべき。