### PR TITLE
Use Geolonia API KEY even if with node runtime

### DIFF
--- a/src/main-node.ts
+++ b/src/main-node.ts
@@ -7,6 +7,9 @@ const fetchOrReadFile = async (
 ): Promise<Response | { json: () => Promise<unknown> }> => {
   const fileURL = new URL(`${Normalize.config.japaneseAddressesApi}${input}`)
   if (fileURL.protocol === 'http:' || fileURL.protocol === 'https:') {
+    if (Normalize.config.geoloniaApiKey) {
+      fileURL.search = `?geolonia-api-key=${Normalize.config.geoloniaApiKey}`
+    }
     return unfetch(fileURL.toString())
   } else if (fileURL.protocol === 'file:') {
     const filePath = decodeURI(fileURL.pathname)

--- a/test/fs.test.ts
+++ b/test/fs.test.ts
@@ -4,24 +4,44 @@ import { performance } from 'perf_hooks'
 import unfetch from 'isomorphic-unfetch'
 jest.mock('isomorphic-unfetch') // disable request for testing
 
-jest.setTimeout(3 * 60 * 1000)
-beforeAll(async () => {
-  config.japaneseAddressesApi =
-    'file://' +
-    path.resolve(__dirname, 'japanese-addresses-master', 'api', 'ja')
-  jest.setTimeout(5000)
+const defaultEndpoint = config.japaneseAddressesApi
+
+describe('file://', () => {
+  jest.setTimeout(3 * 60 * 1000)
+  beforeAll(async () => {
+    config.japaneseAddressesApi =
+      'file://' +
+      path.resolve(__dirname, 'japanese-addresses-master', 'api', 'ja')
+    jest.setTimeout(5000)
+  })
+
+  test('normalize should complete in the local environment', async () => {
+    const started1 = performance.now()
+    await normalize('京都府京田辺市同志社山手４丁目１－４３')
+    const finished1 = performance.now()
+    console.log('nocache performance(ms): ', finished1 - started1)
+
+    const started2 = performance.now()
+    await normalize('京都府京田辺市同志社山手４丁目１－４４')
+    const finished2 = performance.now()
+    console.log('with-cache performance(ms): ', finished2 - started2)
+
+    expect(unfetch).not.toBeCalled()
+  })
 })
 
-test('normalize should complete in the local environment', async () => {
-  const started1 = performance.now()
-  await normalize('京都府京田辺市同志社山手４丁目１－４３')
-  const finished1 = performance.now()
-  console.log('nocache performance(ms): ', finished1 - started1)
+describe('http://', () => {
+  jest.setTimeout(3 * 60 * 1000)
+  beforeAll(async () => {
+    config.japaneseAddressesApi = defaultEndpoint
+    config.geoloniaApiKey = 'MY-KEY'
+    jest.setTimeout(5000)
+  })
 
-  const started2 = performance.now()
-  await normalize('京都府京田辺市同志社山手４丁目１－４４')
-  const finished2 = performance.now()
-  console.log('with-cache performance(ms): ', finished2 - started2)
-
-  expect(unfetch).not.toBeCalled()
+  test('Should request with Geolonia backend', async () => {
+    await normalize('京都府京田辺市同志社山手４丁目１－４４')
+    expect(unfetch).toBeCalled()
+    const args = (unfetch as jest.Mock).mock.calls[0]
+    expect(args[0]).toMatch(/geolonia-api-key=MY-KEY$/)
+  })
 })


### PR DESCRIPTION
Node.js 用のエントリポイントで Geolonia API Key を読み込むようにするのを忘れており、ブラウザだけしか対応していなかったため、追加