### PR TITLE
Fix endpoint customizing bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/normalize-japanese-addresses",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/normalize-japanese-addresses",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "@geolonia/japanese-numeral": "^0.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/normalize-japanese-addresses",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "",
   "browser": "./dist/main-browser.js",
   "main": "./dist/main-node.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "npm run test:main && npm run test:addresses && npm run test:node && npm run test:residential",
     "test:main": "jest test/main.test.ts",
     "test:addresses": "jest test/addresses.test.ts",
-    "test:residential": "jest test/residential.test.ts",
+    "test:residential": "jest test/residential.test.ts --runInBand",
     "test:node": "curl -sL https://github.com/geolonia/japanese-addresses/archive/refs/heads/master.tar.gz | tar xvfz - -C ./test > /dev/null 2>&1 && jest test/fs.test.ts",
     "test:generate-test-data": "npx ts-node -O '{\"module\":\"commonjs\"}' test/build-test-data.ts > test/addresses.csv",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.test.ts\" --fix",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,9 @@
 import { Config } from './normalize'
 
+export const gh_pages_endpoint =
+  'https://geolonia.github.io/japanese-addresses/api/ja'
+
 export const currentConfig: Config = {
-  japaneseAddressesApi: 'https://geolonia.github.io/japanese-addresses/api/ja',
+  japaneseAddressesApi: gh_pages_endpoint,
   townCacheSize: 1_000,
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,5 +1,5 @@
 import { number2kanji } from '@geolonia/japanese-numeral'
-import { currentConfig } from './config'
+import { currentConfig, gh_pages_endpoint } from './config'
 import { kan2num } from './lib/kan2num'
 import { zen2han } from './lib/zen2han'
 import { patchAddr } from './lib/patchAddr'
@@ -192,9 +192,12 @@ export const normalize: Normalizer = async (
   if (option.geoloniaApiKey || config.geoloniaApiKey) {
     option.level = 8
     option.geoloniaApiKey && (config.geoloniaApiKey = option.geoloniaApiKey)
-    // TODO: japanese-addresses.geolonia.com を作成後に置き換え
-    config.japaneseAddressesApi =
-      'https://japanese-addresses-dev.geolonia.com/next/ja'
+    // API キーがある場合は、 Geolonia SaaS に切り替え。
+    // ただし、config を書き換えて別のエンドポイントを使うようにカスタマイズしているケースがあるので、その場合は config に既に入っている値を優先
+    if (config.japaneseAddressesApi === gh_pages_endpoint) {
+      config.japaneseAddressesApi =
+        'https://japanese-addresses.geolonia.com/next/ja'
+    }
   }
 
   /**

--- a/test/residential.test.ts
+++ b/test/residential.test.ts
@@ -1,51 +1,123 @@
 import * as Normalize from '../src/normalize'
 import { normalize } from '../src/main-node'
 import unfetch from 'isomorphic-unfetch'
+import { gh_pages_endpoint } from '../src/config'
 
-beforeAll(() => {
-  Normalize.__internals.fetch = (input: string) => {
-    let url = new URL(
-      `${Normalize.config.japaneseAddressesApi}${input}`,
-    ).toString()
-    if (Normalize.config.geoloniaApiKey) {
-      url += `?geolonia-api-key=${Normalize.config.geoloniaApiKey}`
+test('default endppoint', () => {
+  expect(Normalize.config.japaneseAddressesApi).toEqual(gh_pages_endpoint)
+})
+
+describe('Request with Geolonia backend', () => {
+  const default_fetch = Normalize.__internals.fetch
+  beforeEach(() => {
+    Normalize.__internals.fetch = (input: string) => {
+      let url = new URL(
+        `${Normalize.config.japaneseAddressesApi}${input}`,
+      ).toString()
+      if (Normalize.config.geoloniaApiKey) {
+        url += `?geolonia-api-key=${Normalize.config.geoloniaApiKey}`
+      }
+      return unfetch(url, { headers: { Origin: 'https://geolonia.com' } })
     }
-    return unfetch(url, { headers: { Origin: 'https://geolonia.com' } })
-  }
-  jest.setTimeout(5000)
-})
-
-test('住居表示', async () => {
-  const normResult = await normalize(
-    '東京都世田谷区北烏山６−２２−２２ おはようビル',
-    {
-      geoloniaApiKey: 'YOUR-API-KEY',
-    },
-  )
-  expect(normResult.level).toEqual(8)
-  expect(normResult.gaiku).toEqual('22')
-  expect(normResult.jyukyo).toEqual('22')
-  expect(normResult.addr).toEqual('おはようビル')
-})
-
-test('住居表示だが、知らない号', async () => {
-  const normResult = await normalize(
-    '東京都世田谷区北烏山６−２２番１２３４５６７８９０号 おはようビル',
-    {
-      geoloniaApiKey: 'YOUR-API-KEY',
-    },
-  )
-  expect(normResult.level).toEqual(7)
-  expect(normResult.gaiku).toEqual('22')
-  expect(normResult.addr).toEqual('-1234567890 おはようビル')
-})
-
-test('住居表示未整備', async () => {
-  const normResult = await normalize('滋賀県米原市甲津原999', {
-    geoloniaApiKey: 'YOUR-API-KEY',
+    jest.setTimeout(5000)
   })
-  expect(normResult.level).toEqual(3)
-  expect(normResult.addr).toEqual('999')
-  expect(normResult.gaiku).toBeUndefined()
-  expect(normResult.jyukyo).toBeUndefined()
+  afterEach(() => {
+    Normalize.__internals.fetch = default_fetch
+  })
+
+  test('住居表示', async () => {
+    const normResult = await normalize(
+      '東京都世田谷区北烏山６−２２−２２ おはようビル',
+      {
+        geoloniaApiKey: 'YOUR-API-KEY',
+      },
+    )
+    expect(normResult.level).toEqual(8)
+    expect(normResult.gaiku).toEqual('22')
+    expect(normResult.jyukyo).toEqual('22')
+    expect(normResult.addr).toEqual('おはようビル')
+  })
+
+  test('住居表示だが、知らない号', async () => {
+    const normResult = await normalize(
+      '東京都世田谷区北烏山６−２２番１２３４５６７８９０号 おはようビル',
+      {
+        geoloniaApiKey: 'YOUR-API-KEY',
+      },
+    )
+    expect(normResult.level).toEqual(7)
+    expect(normResult.gaiku).toEqual('22')
+    expect(normResult.addr).toEqual('-1234567890 おはようビル')
+  })
+
+  test('住居表示未整備', async () => {
+    const normResult = await normalize('滋賀県米原市甲津原999', {
+      geoloniaApiKey: 'YOUR-API-KEY',
+    })
+    expect(normResult.level).toEqual(3)
+    expect(normResult.addr).toEqual('999')
+    expect(normResult.gaiku).toBeUndefined()
+    expect(normResult.jyukyo).toBeUndefined()
+  })
+})
+
+describe('tests for config', () => {
+  test('endpoint customization', async () => {
+    const default_url = Normalize.config.japaneseAddressesApi
+    Normalize.config.japaneseAddressesApi = 'hello'
+    try {
+      await normalize('東京都世田谷区北烏山６−２２−２２ おはようビル')
+    } catch {
+    } finally {
+      expect(Normalize.config.japaneseAddressesApi).toEqual('hello')
+      // clean up
+      Normalize.config.japaneseAddressesApi = default_url
+    }
+  })
+
+  test('with Geolonia API Key', async () => {
+    const default_config = { ...Normalize.config }
+    try {
+      await normalize('東京都世田谷区北烏山６−２２−２２ おはようビル', {
+        geoloniaApiKey: 'another-api-key',
+      })
+    } catch {
+    } finally {
+      expect(Normalize.config.japaneseAddressesApi).toEqual(
+        'https://japanese-addresses.geolonia.com/next/ja',
+      )
+      // @ts-ignore - clean up
+      Normalize.config = default_config
+    }
+  })
+
+  test('endpoint customization with Geolonia API Key', async () => {
+    const default_url = Normalize.config.japaneseAddressesApi
+    Normalize.config.japaneseAddressesApi = 'hello'
+    try {
+      await normalize('東京都世田谷区北烏山６−２２−２２ おはようビル', {
+        geoloniaApiKey: 'another-api-key',
+      })
+    } catch {
+    } finally {
+      expect(Normalize.config.japaneseAddressesApi).toEqual('hello')
+      // clean up
+      Normalize.config.japaneseAddressesApi = default_url
+    }
+  })
+
+  test('also works with dev backend', async () => {
+    const default_url = Normalize.config.japaneseAddressesApi
+    Normalize.config.japaneseAddressesApi =
+      'https://japanese-addresses-dev.geolonia.com/next/ja'
+    const result = await normalize(
+      '東京都世田谷区北烏山６−２２−２２ おはようビル',
+      {
+        geoloniaApiKey: 'YOUR-API-KEY',
+      },
+    )
+    expect(result.level).toEqual(8)
+    // clean up
+    Normalize.config.japaneseAddressesApi = default_url
+  })
 })


### PR DESCRIPTION
- API キーを入れるとエンドポイントのカスタマイズができず、Geolonia のバックエンドとしか通信できなかった。他のエンドポイントを使うことを想定してカスタマイズできるように修正
- japanese-addresses-dev.geolonia.com -> japanese-addresses.geolonia.com に変更（後者をデプロイした）