### PR TITLE
ESMビルドの追加

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -25,4 +25,13 @@ export default [
     output: { file: pkg.main, format: 'cjs' },
     plugins: [typescript()],
   },
+  {
+    input: 'src/main-es.ts',
+    output: {
+      dir: 'dist',
+      name: 'normalize',
+      format: 'esm',
+    },
+    plugins: [typescript(), resolve({ browser: true }), commonjs()],
+  },
 ]

--- a/src/main-es.ts
+++ b/src/main-es.ts
@@ -1,0 +1,4 @@
+import * as Normalize from './normalize'
+
+export const config = Normalize.config
+export const normalize = Normalize.normalize

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -2,8 +2,9 @@
 
 import { normalize as normalizerForNode } from '../src/main-node'
 import { normalize as normalizerForBrowser } from '../src/main-browser'
+import { normalize as normalizerForES } from '../src/main-es'
 
-const cases: [runtime: string, normalizer: typeof normalizerForNode | typeof normalizerForBrowser][] = [['node', normalizerForNode], ['browser', normalizerForBrowser]]
+const cases: [runtime: string, normalizer: typeof normalizerForNode | typeof normalizerForBrowser | typeof normalizerForES][] = [['node', normalizerForNode], ['browser', normalizerForBrowser], ['es', normalizerForES]]
 
 for (const [runtime, normalize] of cases) {
   describe(`tests for ${runtime} entry point`, () => {


### PR DESCRIPTION
DenoやブラウザからESモジュールとして使える main-es.js ビルドオプションを追加しました
今までの Node用、ブラウザ用には影響ありません