### PR TITLE
Add 柿碕町 patch

### DIFF
--- a/src/lib/dict.ts
+++ b/src/lib/dict.ts
@@ -29,6 +29,7 @@ export const toRegexPattern = (string: string) => {
   _str = _str
     .replace(/三栄町|四谷三栄町/g, '(三栄町|四谷三栄町)')
     .replace(/鬮野川|くじ野川|くじの川/g, '(鬮野川|くじ野川|くじの川)')
+    .replace(/柿碕町|柿さき町/g, '(柿碕町|柿さき町)')
     .replace(/通り|とおり/g, '(通り|とおり)')
     .replace(/埠頭|ふ頭/g, '(埠頭|ふ頭)')
     .replace(/番町|番丁/g, '(番町|番丁)')

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1093,5 +1093,12 @@ for (const [runtime, normalize] of cases) {
       expect(res.town).toEqual('池麸町')
       expect(res.level).toEqual(3)
     })
+
+    test('柿碕町|柿さき町', async () => {
+      const address = '愛知県安城市柿碕町'
+      const res = await normalize(address)
+      expect(res.town).toEqual('柿さき町')
+      expect(res.level).toEqual(3)
+    })
   })
 }


### PR DESCRIPTION
#190 への修正。

位置参照情報由来の Geolonia 住所マスターでは「柿さき町」として登録されているため「柿碕町」-> 「柿さき町」に寄せられるように修正。
ふりがなの情報をもとに寄せているわけではないので、この修正では今後同様のケースが発見された場合には対応できないが、現在のところこの 1例だけのため、一旦ハードコードすることで対応したいです。

なお平仮名になっている背景は「公用文で使われる漢字は常用漢字のみとするべき」というルールで運用されているからかもしれません。