### PR TITLE
x.y.z のタグがプッシュされた際にリリースを作成するActionsの作成

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,22 @@
+name: Auto Release
+
+on:
+  create:
+    tags:
+      - '*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.event.inputs.tag }}
+          tag_name: ${{ github.event.inputs.tag }}
+          generate_release_notes: true

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,9 +1,11 @@
 name: Auto Release
 
+permissions:
+  contents: write
 on:
   create:
     tags:
-      - '*.*.*'
+      - 'v*.*.*'
 
 jobs:
   release:
@@ -11,12 +13,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ github.event.inputs.tag }}
           tag_name: ${{ github.event.inputs.tag }}
           generate_release_notes: true


### PR DESCRIPTION
初めまして！

[#212](https://github.com/geolonia/normalize-japanese-addresses/issues/212)自動リリースの作成を行うブランチを作成しました。

- [x] 名前が「x.y.z」形式のタグが生成されると実行されて、以下のステータスでリリースを作成します。
**リリース名**： タグ名と同じ(x.y.z)
**リリースノート**： 手動リリース時の「generate release notes」ボタンを押下時と同じ

貢献方法の詳細が見当たらず、プルリクエストや貢献の方法が誤っていましたらすみません。
