### PR TITLE
#222 tagのpushをトリガにリリースワークフローが動作するように修正

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -3,7 +3,7 @@ name: Auto Release
 permissions:
   contents: write
 on:
-  create:
+  push:
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
### バグ修正
以下のバグを修正しました。
- #222 

### 修正内容
[こちらのページ](https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#%E3%83%96%E3%83%A9%E3%83%B3%E3%83%81%E3%81%A8%E3%82%BF%E3%82%B0%E3%82%92%E5%90%AB%E3%82%81%E3%82%8B%E4%BE%8B)を参考に修正を行なっています。