### PR TITLE
Re-introduce main and types fields in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 
 # production
 /build
-/demo/main-browser-esm.js*
+/demo/main-browser-esm.mjs*
 
 # misc
 .DS_Store

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,7 +21,7 @@
   <script src="https://unpkg.com/react@18.3.1/umd/react.production.min.js"></script>
   <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"></script>
   <script type="module">
-    import { normalize } from './main-browser-esm.js';
+    import { normalize } from './main-browser-esm.mjs';
     import htm from 'https://unpkg.com/htm@3.1.1/dist/htm.module.js?module';
     const html = htm.bind(React.createElement);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@geolonia/japanese-addresses-v2": "^0.0.3",
+        "@geolonia/japanese-addresses-v2": "0.0.5",
         "@geolonia/japanese-numeral": "^1.0.2",
         "lru-cache": "^11.0.1",
         "papaparse": "^5.4.1",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@geolonia/japanese-addresses-v2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@geolonia/japanese-addresses-v2/-/japanese-addresses-v2-0.0.3.tgz",
-      "integrity": "sha512-K2I6vWraZsINolL5Iox5DkptlFmow6x5FWBvjbNE/1qDfQJTHx3ucDKKY6I0id2/yS2fgHNzFmXZ0IlxBhKT2w==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@geolonia/japanese-addresses-v2/-/japanese-addresses-v2-0.0.5.tgz",
+      "integrity": "sha512-oQsBRSCGVp18xDpHMGjudJuOmr5NNu4D+LSljAGW2w2oyDTa7KM34Id6ZSILBs/PqvKGfvpMCb8aOfW+tblMWg==",
       "license": "MIT"
     },
     "node_modules/@geolonia/japanese-numeral": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "3.0.0",
   "description": "",
   "type": "module",
+  "main": "./dist/main-node-cjs.cjs",
+  "types": "./dist/main-node.d.ts",
   "exports": {
     "node": {
       "import": "./dist/main-node-esm.js",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "types": "./dist/main-node.d.ts",
   "exports": {
     "node": {
-      "import": "./dist/main-node-esm.js",
+      "import": "./dist/main-node-esm.mjs",
       "require": "./dist/main-node-cjs.cjs",
       "types": "./dist/main-node.d.ts"
     },
     "browser": {
-      "import": "./dist/main-browser-esm.js",
+      "import": "./dist/main-browser-esm.mjs",
       "default": "./dist/main-browser-umd.js",
       "types": "./dist/main-browser.d.ts"
     }
@@ -24,7 +24,7 @@
     "test:addresses": "node --test --import tsx ./test/addresses.test.ts",
     "test:generate-test-data": "tsx test/build-test-data.ts > test/addresses.csv",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.test.ts\" --fix",
-    "build": "npm run clean && rollup -c rollup.config.js && shx cp ./dist/main-browser-esm.js* ./demo/",
+    "build": "npm run clean && rollup -c rollup.config.js && shx cp ./dist/main-browser-esm.mjs* ./demo/",
     "clean": "shx rm -rf dist"
   },
   "engines": {
@@ -54,7 +54,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "@geolonia/japanese-addresses-v2": "^0.0.3",
+    "@geolonia/japanese-addresses-v2": "0.0.5",
     "@geolonia/japanese-numeral": "^1.0.2",
     "lru-cache": "^11.0.1",
     "papaparse": "^5.4.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,7 +38,7 @@ export default [
   {
     input: 'src/main-browser.ts',
     output: {
-      file: './dist/main-browser-esm.js',
+      file: './dist/main-browser-esm.mjs',
       name: 'normalize',
       format: 'esm',
       sourcemap: true,
@@ -55,13 +55,14 @@ export default [
     input: 'src/main-node.ts',
     external: [
       '@geolonia/japanese-numeral',
+      '@geolonia/japanese-addresses-v2',
       'papaparse',
       'undici',
       'lru-cache',
       'node:fs',
     ],
     output: {
-      file: './dist/main-node-esm.js',
+      file: './dist/main-node-esm.mjs',
       format: 'esm',
       sourcemap: true,
     },
@@ -71,6 +72,7 @@ export default [
     input: 'src/main-node.ts',
     external: [
       '@geolonia/japanese-numeral',
+      '@geolonia/japanese-addresses-v2',
       'papaparse',
       'undici',
       'lru-cache',


### PR DESCRIPTION
TypeScript with "moduleResolution": "node" won't look at at the "exports" field, so we add main and types for backward compatibility

Ref #242