### PR TITLE
「驒」と「騨」の表記ゆれへの対応

### DIFF
--- a/src/lib/dictionaries/jisDai2.ts
+++ b/src/lib/dictionaries/jisDai2.ts
@@ -291,4 +291,5 @@ export const jisDai2Dictionary: Dictionary[] = [
   { src: '籠', dst: '篭' },
   { src: '彌', dst: '弥' },
   { src: '麩', dst: '麸' },
+  { src: '驒', dst: '騨' },
 ]

--- a/test/main/main.test.ts
+++ b/test/main/main.test.ts
@@ -229,6 +229,15 @@ describe(`basic tests`, () => {
         assert.strictEqual(res.level, 3)
       }
     })
+
+    test('驒 -> 騨', async () => {
+      const addresses = ['岐阜県飛驒市', '岐阜県飛騨市']
+      for (const address of addresses) {
+        const res = await normalize(address)
+        assert.strictEqual(res.city, '飛騨市')
+        assert.strictEqual(res.level, 2)
+      }
+    })
   })
 
   test('柿碕町|柿さき町', async () => {


### PR DESCRIPTION
### 概要
- fix #252 
- 「驒」と「騨」の表記ゆれへに対応します

### その他
- テストコードは 0e10bda2 での対応を参考に書いてみました。