### PR TITLE
NormalizeResult 型をexportする

### DIFF
--- a/src/main-node.ts
+++ b/src/main-node.ts
@@ -3,6 +3,8 @@ import { __internals, FetchOptions, FetchResponseLike } from './config'
 import { promises as fs } from 'node:fs'
 import { fetch } from 'undici'
 
+export type { NormalizeResult } from './types'
+
 export const requestHandlers = {
   file: async (fileURL: URL, options?: FetchOptions) => {
     const o = options || {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
 import * as Normalize from './normalize'
 
+export type { NormalizeResult } from './types'
+
 export const version = Normalize.version
 export const config = Normalize.config
 export const normalize = Normalize.normalize


### PR DESCRIPTION
TypeScriptでnormalizeの結果を扱うために必要な場面がありました