### PR TITLE
失敗していた結合テストを修正

### DIFF
--- a/test/integration/browser.test.ts
+++ b/test/integration/browser.test.ts
@@ -10,6 +10,7 @@ const runTest = (type: 'esm' | 'umd') => {
     const browser = await puppeteer.launch({
       args: [
         '--disable-web-security', // for loading files from file://
+        '--no-sandbox', // for running in CI
       ],
     })
     try {


### PR DESCRIPTION
Ubuntu 23.10 以降 でPuppeteer が Chromiumを起動時に Sandbox を作成できなくて失敗していたので修正しました。

```
No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, ...
```

参考
https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md