### PR TITLE
Fix prefecture inference for abbreviated addresses

### DIFF
--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -191,6 +191,12 @@ export const normalize: Normalizer = async (
   let point: NormalizeResultPoint | undefined
   let addr: string | undefined
   let level = 0
+  let prefMatchWithoutSuffix:
+    | {
+        pref: SinglePrefecture
+        other: string
+      }
+    | undefined
 
   // 都道府県名の正規化
 
@@ -213,6 +219,16 @@ export const normalize: Normalizer = async (
   for (const [_pref, pattern] of prefPatterns) {
     const match = other.match(pattern)
     if (match) {
+      // A prefecture suffix is optional to support inputs such as `東京`.
+      // Defer that match until after trying city-name inference so that a
+      // city such as `福島町` is not mistaken for `福島県`.
+      if (!match[1]) {
+        prefMatchWithoutSuffix = {
+          pref: _pref,
+          other: other.substring(match[0].length),
+        }
+        continue
+      }
       pref = _pref
       other = other.substring(match[0].length) // 都道府県名以降の住所
       point = prefectureToResultPoint(pref)
@@ -262,6 +278,12 @@ export const normalize: Normalizer = async (
           point = upgradePoint(point, machiAzaToResultPoint(town))
         }
       }
+    }
+
+    if (!pref && prefMatchWithoutSuffix) {
+      pref = prefMatchWithoutSuffix.pref
+      other = prefMatchWithoutSuffix.other
+      point = prefectureToResultPoint(pref)
     }
   }
 

--- a/test/main/main.test.ts
+++ b/test/main/main.test.ts
@@ -67,6 +67,17 @@ describe(`basic tests`, () => {
     })
   })
 
+  test('It should infer 北海道 from `福島町` without mistaking it for 福島県', async () => {
+    const res = await normalize('福島町字三岳４５番地の１３')
+    assertMatchCloseTo(res, {
+      pref: '北海道',
+      city: '松前郡福島町',
+      town: '字三岳',
+      addr: '45-13',
+      level: 8,
+    })
+  })
+
   test('It should get the level `2` with `東京都港区あいうえお`', async () => {
     const res = await normalize('東京都港区あいうえお')
     assertMatchCloseTo(res, {


### PR DESCRIPTION
## Summary

- Defer prefecture matches without a suffix until city-name inference has been attempted.
- Add a regression test for `福島町字三岳４５番地の１３`.

## Why

When the prefecture suffix was omitted, `福島町` matched the optional-suffix pattern for `福島県` before the normalizer could infer `北海道` from `松前郡福島町`.

## Validation

- `npm run lint` passed.
- Added a regression test covering the expected prefecture, city, town, and address.
- The live address-data API was unavailable during the local test run, so the full API-backed test could not complete.

Fixes #271
