### PR TITLE
住所データの取得失敗を検知して再試行し、黙って縮退しないようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,30 @@ normalize('北海道札幌市西区24-2-2-3-3', { level: 1 }).then(result => {
 })
 ```
 
+### エラー処理
+
+`normalize()` は住所データの取得に失敗した場合、例外を投げます。取得できなかった住所を低い `level` で返すことはしません。低い `level` が返るのは、入力された住所文字列をそこまでしか判別できなかった場合だけです。
+
+一過性の失敗と判断できるもの（HTTP 5xx、408、425、429、ネットワークエラー、200 で返されたエラーページ）は、指数バックオフで最大 3 回まで自動的に再試行します。それでも回復しない場合に例外となります。404 のように再試行しても解決しない失敗は、その場で例外になります。
+
+例外の `message` には、どのデータの取得に失敗したかと HTTP ステータスが含まれます。`config.japaneseAddressesApi` に `file://` を指定している場合は、`code` プロパティに `ENOENT` などの Node.js のエラーコードが入ります。
+
+大量の住所を一括で正規化する場合は、1 件の失敗で全体が止まらないように例外を捕捉してください。
+
+```javascript
+const { normalize } = require('@geolonia/normalize-japanese-addresses')
+
+for (const address of addresses) {
+  try {
+    const result = await normalize(address)
+    console.log(result)
+  } catch (error) {
+    // 住所データの取得に失敗した。時間を置いて再度実行する
+    console.error(address, error.message)
+  }
+}
+```
+
 ### グローバルオプション
 
 以下のパラメーターを変更することでライブラリの動作全体に関わる設定が変更できます。

--- a/README.md
+++ b/README.md
@@ -88,22 +88,24 @@ normalize('北海道札幌市西区24-2-2-3-3', { level: 1 }).then(result => {
 
 `normalize()` は住所データの取得に失敗した場合、例外を投げます。取得できなかった住所を低い `level` で返すことはしません。低い `level` が返るのは、入力された住所文字列をそこまでしか判別できなかった場合だけです。
 
-一過性の失敗と判断できるもの（HTTP 5xx、408、425、429、ネットワークエラー、200 で返されたエラーページ）は、指数バックオフで最大 3 回まで自動的に再試行します。それでも回復しない場合に例外となります。404 のように再試行しても解決しない失敗は、その場で例外になります。
+一過性の失敗と判断できるもの（HTTP 5xx、408、425、429、ネットワークエラー、200 で返されたエラーページ）は、指数バックオフで自動的に再試行します。試行回数は初回の要求を含めて最大 3 回、つまり再試行は最大 2 回です。それでも回復しない場合に例外となります。404 のように再試行しても解決しない失敗は、その場で例外になります。
 
-例外の `message` には、どのデータの取得に失敗したかと HTTP ステータスが含まれます。`config.japaneseAddressesApi` に `file://` を指定している場合は、`code` プロパティに `ENOENT` などの Node.js のエラーコードが入ります。
+例外の `message` には、どのデータの取得に失敗したかと失敗の原因が含まれます。原因は、HTTP エラーの場合はステータスコード、本文が期待どおりでない場合は期待したバイト長と実際のバイト長、ネットワークエラーの場合は元のエラーメッセージです。`config.japaneseAddressesApi` に `file://` を指定している場合は、`code` プロパティに `ENOENT` などの Node.js のエラーコードが入ります。
 
 大量の住所を一括で正規化する場合は、1 件の失敗で全体が止まらないように例外を捕捉してください。
 
 ```javascript
 const { normalize } = require('@geolonia/normalize-japanese-addresses')
 
-for (const address of addresses) {
-  try {
-    const result = await normalize(address)
-    console.log(result)
-  } catch (error) {
-    // 住所データの取得に失敗した。時間を置いて再度実行する
-    console.error(address, error.message)
+async function normalizeAll(addresses) {
+  for (const address of addresses) {
+    try {
+      const result = await normalize(address)
+      console.log(result)
+    } catch (error) {
+      // 住所データの取得に失敗した。時間を置いて再度実行する
+      console.error(address, error.message)
+    }
   }
 }
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,12 @@ export type FetchResponseLike = {
   json: () => Promise<unknown>
   text: () => Promise<string>
   ok: boolean
+  /**
+   * HTTP のステータスコード。
+   * 再試行するべき失敗かどうかの判定に使う。ファイルシステムから読む場合など、
+   * ステータスコードの概念が無い実装では省略できる。
+   */
+  status?: number
 }
 
 export type FetchLike = (

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -2,7 +2,12 @@ import { toRegexPattern } from './dict'
 import { kan2num } from './kan2num'
 import Papaparse from 'papaparse'
 import { LRUCache } from 'lru-cache'
-import { currentConfig, FetchOptions, __internals } from '../config'
+import {
+  currentConfig,
+  FetchOptions,
+  FetchResponseLike,
+  __internals,
+} from '../config'
 import { findKanjiNumbers, kanji2number } from '@geolonia/japanese-numeral'
 import {
   cityName,
@@ -63,6 +68,15 @@ const isRetryableError = (e: unknown) => {
   return code !== 'ENOENT' && code !== 'ENOTDIR'
 }
 
+/**
+ * 応答は ok だが本文が期待どおりでないことを表す。
+ *
+ * @remarks
+ * CDN が 200 でエラーページやチャレンジページを返すことがあり、これは
+ * 5xx と同じく一過性の失敗なので再試行の対象として扱う。
+ */
+class InvalidBodyError extends Error {}
+
 const decodeTarget = (input: string) => {
   try {
     // どのデータの取得に失敗したのかを読めるようにする
@@ -98,13 +112,22 @@ const fetchError = (input: string, detail: string, cause?: unknown) => {
  * 縮退していた。呼び出し側からは正常な結果と区別が付かないため、
  * ここで明示的に失敗させる。
  *
+ * 本文の読み取りを呼び出し側から渡すのは、応答が ok でも本文が期待どおりで
+ * ない場合を再試行の対象にするためである。`readBody` が
+ * {@link InvalidBodyError} を投げた場合は 5xx と同じ扱いになる。
+ *
  * @param input - 取得するデータのパス
  * @param options - Range リクエストの範囲
+ * @param readBody - 応答から本文を読み取る関数
  */
-async function fetchWithRetry(input: string, options?: FetchOptions) {
-  let lastStatus: number | undefined
+async function fetchWithRetry<T>(
+  input: string,
+  options: FetchOptions | undefined,
+  readBody: (resp: FetchResponseLike) => Promise<T>,
+): Promise<T> {
+  let lastDetail = ''
   for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
-    let resp
+    let resp: FetchResponseLike
     try {
       resp = await __internals.fetch(input, options)
     } catch (e) {
@@ -116,20 +139,30 @@ async function fetchWithRetry(input: string, options?: FetchOptions) {
     }
 
     if (resp.ok) {
-      return resp
+      try {
+        return await readBody(resp)
+      } catch (e) {
+        if (!(e instanceof InvalidBodyError)) {
+          throw e
+        }
+        lastDetail = `: ${e.message}`
+        if (attempt === MAX_FETCH_ATTEMPTS) {
+          break
+        }
+        await sleep(FETCH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
+        continue
+      }
     }
 
-    lastStatus = resp.status
+    lastDetail =
+      typeof resp.status === 'undefined' ? '' : ` (HTTP ${resp.status})`
     if (attempt === MAX_FETCH_ATTEMPTS || !isRetryableStatus(resp.status)) {
       break
     }
     await sleep(FETCH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
   }
 
-  throw fetchError(
-    input,
-    typeof lastStatus === 'undefined' ? '' : ` (HTTP ${lastStatus})`,
-  )
+  throw fetchError(input, lastDetail)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -159,8 +192,11 @@ export const getPrefectures = async () => {
     return cachedPrefectures
   }
 
-  const prefsResp = await fetchWithRetry('.json', {}) // ja.json
-  const data = (await prefsResp.json()) as PrefectureApi
+  const data = await fetchWithRetry(
+    '.json', // ja.json
+    {},
+    async (resp) => (await resp.json()) as PrefectureApi,
+  )
   return cachePrefectures(data)
 }
 
@@ -222,11 +258,11 @@ export const getTowns = async (
     return cachedTown
   }
 
-  const townsResp = await fetchWithRetry(
+  const towns = await fetchWithRetry(
     ['', encodeURI(pref), encodeURI(city) + `.json?v=${apiVersion}`].join('/'),
     {},
+    async (resp) => (await resp.json()) as MachiAzaApi,
   )
-  const towns = (await townsResp.json()) as MachiAzaApi
   return (cachedTowns[cacheKey] = towns)
 }
 
@@ -241,7 +277,7 @@ async function fetchSubresource(
 ) {
   const prefN = prefectureName(pref)
   const cityN = cityName(city)
-  const resp = await fetchWithRetry(
+  return fetchWithRetry(
     [
       '',
       encodeURI(prefN),
@@ -251,8 +287,20 @@ async function fetchSubresource(
       offset: row.start,
       length: row.length,
     },
+    async (resp) => {
+      const text = await resp.text()
+      // Range で要求した長さは既知なので、バイト長を確認するだけで
+      // 200 で返されたエラーページと、Range を無視して全文が返された応答を
+      // どちらも捕まえられる。ブラウザ向けの bundle にも載るため Buffer は使わない。
+      const actual = new TextEncoder().encode(text).length
+      if (actual !== row.length) {
+        throw new InvalidBodyError(
+          `期待 ${row.length} バイト、実際 ${actual} バイト`,
+        )
+      }
+      return text
+    },
   )
-  return resp.text()
 }
 
 type RsdtDataRow = {

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -2,7 +2,7 @@ import { toRegexPattern } from './dict'
 import { kan2num } from './kan2num'
 import Papaparse from 'papaparse'
 import { LRUCache } from 'lru-cache'
-import { currentConfig, __internals } from '../config'
+import { currentConfig, FetchOptions, __internals } from '../config'
 import { findKanjiNumbers, kanji2number } from '@geolonia/japanese-numeral'
 import {
   cityName,
@@ -39,6 +39,77 @@ const cache = new LRUCache({
   max: currentConfig.cacheSize,
 })
 
+const MAX_FETCH_ATTEMPTS = 3
+const FETCH_RETRY_BASE_DELAY_MS = 100
+/** 一過性の失敗とみなして再試行するステータスコード */
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504])
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const isRetryableStatus = (status: number | undefined) =>
+  // ステータスコードを返さない実装では一過性かどうかを区別できないため、再試行する
+  typeof status === 'undefined' || RETRYABLE_STATUS.has(status)
+
+const isRetryableError = (e: unknown) => {
+  const code = (e as { code?: string } | null)?.code
+  // ファイルが無いことは再試行しても解決しない
+  return code !== 'ENOENT' && code !== 'ENOTDIR'
+}
+
+/**
+ * 住所データを取得する。
+ *
+ * @remarks
+ * 応答が ok でない場合、一過性の失敗であれば数回まで再試行し、
+ * それでも回復しなければ例外を投げる。
+ *
+ * 以前は ok を確認せずに本文を解析していたため、CDN が一過性のエラーを返すと
+ * エラーページの中身を住所データとして読み、住所が黙って低い level に
+ * 縮退していた。呼び出し側からは正常な結果と区別が付かないため、
+ * ここで明示的に失敗させる。
+ *
+ * @param input - 取得するデータのパス
+ * @param options - Range リクエストの範囲
+ */
+async function fetchWithRetry(input: string, options?: FetchOptions) {
+  let lastStatus: number | undefined
+  for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+    let resp
+    try {
+      resp = await __internals.fetch(input, options)
+    } catch (e) {
+      if (attempt === MAX_FETCH_ATTEMPTS || !isRetryableError(e)) {
+        throw e
+      }
+      await sleep(FETCH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
+      continue
+    }
+
+    if (resp.ok) {
+      return resp
+    }
+
+    lastStatus = resp.status
+    if (attempt === MAX_FETCH_ATTEMPTS || !isRetryableStatus(resp.status)) {
+      break
+    }
+    await sleep(FETCH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
+  }
+
+  const status =
+    typeof lastStatus === 'undefined' ? '' : ` (HTTP ${lastStatus})`
+  let target = input
+  try {
+    // どのデータの取得に失敗したのかを読めるようにする
+    target = decodeURI(input)
+  } catch {
+    // デコードできない場合は元のまま使う
+  }
+  throw new Error(
+    `[normalize-japanese-addresses] 住所データの取得に失敗しました: ${target}${status}`,
+  )
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 async function fetchFromCache<T extends {}>(
   key: string,
@@ -66,7 +137,7 @@ export const getPrefectures = async () => {
     return cachedPrefectures
   }
 
-  const prefsResp = await __internals.fetch('.json', {}) // ja.json
+  const prefsResp = await fetchWithRetry('.json', {}) // ja.json
   const data = (await prefsResp.json()) as PrefectureApi
   return cachePrefectures(data)
 }
@@ -129,7 +200,7 @@ export const getTowns = async (
     return cachedTown
   }
 
-  const townsResp = await __internals.fetch(
+  const townsResp = await fetchWithRetry(
     ['', encodeURI(pref), encodeURI(city) + `.json?v=${apiVersion}`].join('/'),
     {},
   )
@@ -148,7 +219,7 @@ async function fetchSubresource(
 ) {
   const prefN = prefectureName(pref)
   const cityN = cityName(city)
-  const resp = await __internals.fetch(
+  const resp = await fetchWithRetry(
     [
       '',
       encodeURI(prefN),

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -39,21 +39,51 @@ const cache = new LRUCache({
   max: currentConfig.cacheSize,
 })
 
+/** 初回の要求を含めた試行回数の上限 */
 const MAX_FETCH_ATTEMPTS = 3
 const FETCH_RETRY_BASE_DELAY_MS = 100
-/** 一過性の失敗とみなして再試行するステータスコード */
-const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504])
+/** サーバー側の一過性の不調とは限らないが、時間を置けば解決しうるもの */
+const RETRYABLE_CLIENT_STATUS = new Set([408, 425, 429])
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-const isRetryableStatus = (status: number | undefined) =>
+const isRetryableStatus = (status: number | undefined) => {
   // ステータスコードを返さない実装では一過性かどうかを区別できないため、再試行する
-  typeof status === 'undefined' || RETRYABLE_STATUS.has(status)
+  if (typeof status === 'undefined') {
+    return true
+  }
+  // 5xx は全て再試行する。配信元の Cloudflare は origin 側の不調に対して
+  // 520 から 527 を返すため、代表的な 500 / 502 / 503 / 504 の列挙では取りこぼす。
+  return status >= 500 || RETRYABLE_CLIENT_STATUS.has(status)
+}
 
 const isRetryableError = (e: unknown) => {
   const code = (e as { code?: string } | null)?.code
   // ファイルが無いことは再試行しても解決しない
   return code !== 'ENOENT' && code !== 'ENOTDIR'
+}
+
+const decodeTarget = (input: string) => {
+  try {
+    // どのデータの取得に失敗したのかを読めるようにする
+    return decodeURI(input)
+  } catch {
+    // デコードできない場合は元のまま使う
+    return input
+  }
+}
+
+const fetchError = (input: string, detail: string, cause?: unknown) => {
+  const error: Error & { code?: string } = new Error(
+    `[normalize-japanese-addresses] 住所データの取得に失敗しました: ${decodeTarget(input)}${detail}`,
+    typeof cause === 'undefined' ? undefined : { cause },
+  )
+  const code = (cause as { code?: string } | null)?.code
+  if (typeof code === 'string') {
+    // 呼び出し側が e.code で分岐できる従来の挙動を保つ
+    error.code = code
+  }
+  return error
 }
 
 /**
@@ -79,7 +109,7 @@ async function fetchWithRetry(input: string, options?: FetchOptions) {
       resp = await __internals.fetch(input, options)
     } catch (e) {
       if (attempt === MAX_FETCH_ATTEMPTS || !isRetryableError(e)) {
-        throw e
+        throw fetchError(input, e instanceof Error ? `: ${e.message}` : '', e)
       }
       await sleep(FETCH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
       continue
@@ -96,17 +126,9 @@ async function fetchWithRetry(input: string, options?: FetchOptions) {
     await sleep(FETCH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
   }
 
-  const status =
-    typeof lastStatus === 'undefined' ? '' : ` (HTTP ${lastStatus})`
-  let target = input
-  try {
-    // どのデータの取得に失敗したのかを読めるようにする
-    target = decodeURI(input)
-  } catch {
-    // デコードできない場合は元のまま使う
-  }
-  throw new Error(
-    `[normalize-japanese-addresses] 住所データの取得に失敗しました: ${target}${status}`,
+  throw fetchError(
+    input,
+    typeof lastStatus === 'undefined' ? '' : ` (HTTP ${lastStatus})`,
   )
 }
 

--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -77,6 +77,24 @@ const isRetryableError = (e: unknown) => {
  */
 class InvalidBodyError extends Error {}
 
+/**
+ * 本文の読み取りや解析の失敗を、再試行の対象として扱える形に変換する。
+ *
+ * @remarks
+ * `resp.json()` は 200 で返されたエラーページに対して構文エラーを投げ、
+ * `resp.text()` は本文の受信が途中で切れた場合に失敗する。どちらも 5xx と
+ * 同じ一過性の失敗なので {@link InvalidBodyError} に変換する。
+ * 再試行しても解決しない失敗は変換せずにそのまま伝播させる。
+ */
+const asInvalidBody = (e: unknown) => {
+  if (!isRetryableError(e)) {
+    return e
+  }
+  return new InvalidBodyError(e instanceof Error ? e.message : String(e), {
+    cause: e,
+  })
+}
+
 const decodeTarget = (input: string) => {
   try {
     // どのデータの取得に失敗したのかを読めるようにする
@@ -126,6 +144,7 @@ async function fetchWithRetry<T>(
   readBody: (resp: FetchResponseLike) => Promise<T>,
 ): Promise<T> {
   let lastDetail = ''
+  let lastCause: unknown
   for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
     let resp: FetchResponseLike
     try {
@@ -146,6 +165,7 @@ async function fetchWithRetry<T>(
           throw e
         }
         lastDetail = `: ${e.message}`
+        lastCause = e.cause ?? e
         if (attempt === MAX_FETCH_ATTEMPTS) {
           break
         }
@@ -162,7 +182,7 @@ async function fetchWithRetry<T>(
     await sleep(FETCH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
   }
 
-  throw fetchError(input, lastDetail)
+  throw fetchError(input, lastDetail, lastCause)
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -195,7 +215,13 @@ export const getPrefectures = async () => {
   const data = await fetchWithRetry(
     '.json', // ja.json
     {},
-    async (resp) => (await resp.json()) as PrefectureApi,
+    async (resp) => {
+      try {
+        return (await resp.json()) as PrefectureApi
+      } catch (e) {
+        throw asInvalidBody(e)
+      }
+    },
   )
   return cachePrefectures(data)
 }
@@ -261,7 +287,13 @@ export const getTowns = async (
   const towns = await fetchWithRetry(
     ['', encodeURI(pref), encodeURI(city) + `.json?v=${apiVersion}`].join('/'),
     {},
-    async (resp) => (await resp.json()) as MachiAzaApi,
+    async (resp) => {
+      try {
+        return (await resp.json()) as MachiAzaApi
+      } catch (e) {
+        throw asInvalidBody(e)
+      }
+    },
   )
   return (cachedTowns[cacheKey] = towns)
 }
@@ -288,7 +320,12 @@ async function fetchSubresource(
       length: row.length,
     },
     async (resp) => {
-      const text = await resp.text()
+      let text: string
+      try {
+        text = await resp.text()
+      } catch (e) {
+        throw asInvalidBody(e)
+      }
       // Range で要求した長さは既知なので、バイト長を確認するだけで
       // 200 で返されたエラーページと、Range を無視して全文が返された応答を
       // どちらも捕まえられる。ブラウザ向けの bundle にも載るため Buffer は使わない。

--- a/test/main/fetch-error.test.ts
+++ b/test/main/fetch-error.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert'
+import http from 'node:http'
+import path from 'node:path'
+import os from 'node:os'
+import fs from 'node:fs'
+import { AddressInfo } from 'node:net'
+import { pipeline } from 'node:stream/promises'
+import { fetch } from 'undici'
+import { normalize, config } from '../../src/main-node'
+
+async function downloadFile(file: string, destDir: string) {
+  const resp = await fetch(
+    `https://japanese-addresses-v2.geoloniamaps.com/api/${file}`,
+  )
+  const outputFile = path.join(destDir, file)
+  await fs.promises.mkdir(path.dirname(outputFile), { recursive: true })
+  const writer = fs.createWriteStream(outputFile)
+  if (!resp.body) {
+    throw new Error('No body')
+  }
+  await pipeline(resp.body, writer)
+}
+
+/** 住居表示のサブリソースに対して、あと何回どのステータスを返すか */
+const subresourceFailure = { remaining: 0, status: 503 }
+/** 住居表示のサブリソースへのリクエスト回数 */
+let subresourceRequests = 0
+
+describe(`データ取得に失敗したときの挙動`, () => {
+  let tmpdir: string
+  let server: http.Server
+
+  before(async () => {
+    tmpdir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'nja-fetch-error-'),
+    )
+    for (const file of [
+      'ja.json',
+      'ja/東京都/渋谷区.json',
+      'ja/東京都/渋谷区-住居表示.txt',
+    ]) {
+      await downloadFile(file, tmpdir)
+    }
+
+    server = http.createServer((req, res) => {
+      const urlPath = decodeURIComponent((req.url ?? '/').split('?')[0])
+
+      if (urlPath.endsWith('-住居表示.txt')) {
+        subresourceRequests += 1
+        if (subresourceFailure.remaining > 0) {
+          subresourceFailure.remaining -= 1
+          res.writeHead(subresourceFailure.status, {
+            'content-type': 'text/plain; charset=utf-8',
+          })
+          // エラーページの本文を返す CDN を模す
+          res.end('<html><body>error</body></html>')
+          return
+        }
+      }
+
+      let body: Buffer
+      try {
+        body = fs.readFileSync(path.join(tmpdir, urlPath))
+      } catch {
+        res.writeHead(404)
+        res.end('not found')
+        return
+      }
+
+      const range = /^bytes=(\d+)-(\d+)$/.exec(req.headers.range ?? '')
+      if (range) {
+        const start = Number(range[1])
+        const end = Number(range[2])
+        const slice = body.subarray(start, end + 1)
+        res.writeHead(206, {
+          'content-length': String(slice.length),
+          'content-range': `bytes ${start}-${end}/${body.length}`,
+        })
+        res.end(slice)
+        return
+      }
+
+      res.writeHead(200, { 'content-length': String(body.length) })
+      res.end(body)
+    })
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const { port } = server.address() as AddressInfo
+    config.japaneseAddressesApi = `http://127.0.0.1:${port}/ja`
+  })
+
+  after(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    )
+    await fs.promises.rm(tmpdir, { recursive: true, force: true })
+  })
+
+  beforeEach(() => {
+    subresourceFailure.remaining = 0
+    subresourceFailure.status = 503
+    subresourceRequests = 0
+  })
+
+  // 町字ごとにキャッシュされるため、テストごとに異なる町字を使う
+
+  test(`一過性の 5xx はリトライして回復する`, async () => {
+    subresourceFailure.remaining = 1
+    subresourceFailure.status = 503
+
+    const res = await normalize('渋谷区道玄坂1-10-8')
+
+    assert.strictEqual(res.level, 8)
+    assert.strictEqual(res.addr, '10-8')
+    assert.strictEqual(subresourceRequests, 2)
+  })
+
+  test(`5xx が続く場合は縮退せずにエラーになる`, async () => {
+    subresourceFailure.remaining = Number.MAX_SAFE_INTEGER
+    subresourceFailure.status = 503
+
+    await assert.rejects(
+      () => normalize('渋谷区神南1-1-1'),
+      (e: Error) => {
+        assert.match(e.message, /住居表示/)
+        assert.match(e.message, /503/)
+        return true
+      },
+    )
+  })
+
+  test(`404 はリトライせずにエラーになる`, async () => {
+    subresourceFailure.remaining = Number.MAX_SAFE_INTEGER
+    subresourceFailure.status = 404
+
+    await assert.rejects(() => normalize('渋谷区桜丘町13-3'))
+    assert.strictEqual(subresourceRequests, 1)
+  })
+})

--- a/test/main/fetch-error.test.ts
+++ b/test/main/fetch-error.test.ts
@@ -13,12 +13,17 @@ async function downloadFile(file: string, destDir: string) {
   const resp = await fetch(
     `https://japanese-addresses-v2.geoloniamaps.com/api/${file}`,
   )
+  // 失敗した応答の本文を保存してしまうと、後でローカルサーバーがそれを 200 で
+  // 返し、セットアップの失敗が分かりにくいテストの失敗に化ける
+  if (!resp.ok) {
+    throw new Error(`Failed to download ${file}: HTTP ${resp.status}`)
+  }
+  if (!resp.body) {
+    throw new Error(`No body: ${file}`)
+  }
   const outputFile = path.join(destDir, file)
   await fs.promises.mkdir(path.dirname(outputFile), { recursive: true })
   const writer = fs.createWriteStream(outputFile)
-  if (!resp.body) {
-    throw new Error('No body')
-  }
   await pipeline(resp.body, writer)
 }
 
@@ -128,6 +133,20 @@ describe(`データ取得に失敗したときの挙動`, () => {
         return true
       },
     )
+    // 初回の要求を含めて 3 回で打ち切る
+    assert.strictEqual(subresourceRequests, 3)
+  })
+
+  test(`Cloudflare の 52x もリトライの対象になる`, async () => {
+    // 配信元の Cloudflare は origin 側の不調に対して 520 から 527 を返す
+    subresourceFailure.remaining = 2
+    subresourceFailure.status = 520
+
+    const res = await normalize('渋谷区恵比寿4-20-3')
+
+    assert.strictEqual(res.level, 8)
+    assert.strictEqual(res.addr, '20-3')
+    assert.strictEqual(subresourceRequests, 3)
   })
 
   test(`404 はリトライせずにエラーになる`, async () => {

--- a/test/main/fetch-error.test.ts
+++ b/test/main/fetch-error.test.ts
@@ -58,7 +58,8 @@ describe(`データ取得に失敗したときの挙動`, () => {
           res.writeHead(subresourceFailure.status, {
             'content-type': 'text/plain; charset=utf-8',
           })
-          // エラーページの本文を返す CDN を模す
+          // エラーページの本文を返す CDN を模す。status に 200 を指定すると
+          // 「ok だが本文がエラーページ」というケースになる
           res.end('<html><body>error</body></html>')
           return
         }
@@ -146,6 +147,33 @@ describe(`データ取得に失敗したときの挙動`, () => {
 
     assert.strictEqual(res.level, 8)
     assert.strictEqual(res.addr, '20-3')
+    assert.strictEqual(subresourceRequests, 3)
+  })
+
+  test(`200 でエラーページが返った場合もリトライして回復する`, async () => {
+    // Range で要求した長さと本文のバイト長が食い違うことで検知する
+    subresourceFailure.remaining = 1
+    subresourceFailure.status = 200
+
+    const res = await normalize('渋谷区宇田川町15-1')
+
+    assert.strictEqual(res.level, 8)
+    assert.strictEqual(res.addr, '15-1')
+    assert.strictEqual(subresourceRequests, 2)
+  })
+
+  test(`200 のエラーページが続く場合は縮退せずにエラーになる`, async () => {
+    subresourceFailure.remaining = Number.MAX_SAFE_INTEGER
+    subresourceFailure.status = 200
+
+    await assert.rejects(
+      () => normalize('渋谷区神宮前6-19-13'),
+      (e: Error) => {
+        assert.match(e.message, /住居表示/)
+        assert.match(e.message, /バイト/)
+        return true
+      },
+    )
     assert.strictEqual(subresourceRequests, 3)
   })
 

--- a/test/main/fetch-error.test.ts
+++ b/test/main/fetch-error.test.ts
@@ -27,10 +27,10 @@ async function downloadFile(file: string, destDir: string) {
   await pipeline(resp.body, writer)
 }
 
-/** 住居表示のサブリソースに対して、あと何回どのステータスを返すか */
-const subresourceFailure = { remaining: 0, status: 503 }
-/** 住居表示のサブリソースへのリクエスト回数 */
-let subresourceRequests = 0
+/** パスの末尾が target に一致する要求に対して、あと何回どのステータスを返すか */
+const failure = { target: '-住居表示.txt', remaining: 0, status: 503 }
+/** target に一致した要求の回数 */
+let targetRequests = 0
 
 describe(`データ取得に失敗したときの挙動`, () => {
   let tmpdir: string
@@ -44,6 +44,10 @@ describe(`データ取得に失敗したときの挙動`, () => {
       'ja.json',
       'ja/東京都/渋谷区.json',
       'ja/東京都/渋谷区-住居表示.txt',
+      // 町字データの取得を失敗させるテスト用。渋谷区は他のテストで
+      // 取得済みになりキャッシュから返るため、別の市区町村が必要
+      'ja/東京都/目黒区.json',
+      'ja/東京都/目黒区-住居表示.txt',
     ]) {
       await downloadFile(file, tmpdir)
     }
@@ -51,11 +55,11 @@ describe(`データ取得に失敗したときの挙動`, () => {
     server = http.createServer((req, res) => {
       const urlPath = decodeURIComponent((req.url ?? '/').split('?')[0])
 
-      if (urlPath.endsWith('-住居表示.txt')) {
-        subresourceRequests += 1
-        if (subresourceFailure.remaining > 0) {
-          subresourceFailure.remaining -= 1
-          res.writeHead(subresourceFailure.status, {
+      if (urlPath.endsWith(failure.target)) {
+        targetRequests += 1
+        if (failure.remaining > 0) {
+          failure.remaining -= 1
+          res.writeHead(failure.status, {
             'content-type': 'text/plain; charset=utf-8',
           })
           // エラーページの本文を返す CDN を模す。status に 200 を指定すると
@@ -104,27 +108,28 @@ describe(`データ取得に失敗したときの挙動`, () => {
   })
 
   beforeEach(() => {
-    subresourceFailure.remaining = 0
-    subresourceFailure.status = 503
-    subresourceRequests = 0
+    failure.target = '-住居表示.txt'
+    failure.remaining = 0
+    failure.status = 503
+    targetRequests = 0
   })
 
   // 町字ごとにキャッシュされるため、テストごとに異なる町字を使う
 
   test(`一過性の 5xx はリトライして回復する`, async () => {
-    subresourceFailure.remaining = 1
-    subresourceFailure.status = 503
+    failure.remaining = 1
+    failure.status = 503
 
     const res = await normalize('渋谷区道玄坂1-10-8')
 
     assert.strictEqual(res.level, 8)
     assert.strictEqual(res.addr, '10-8')
-    assert.strictEqual(subresourceRequests, 2)
+    assert.strictEqual(targetRequests, 2)
   })
 
   test(`5xx が続く場合は縮退せずにエラーになる`, async () => {
-    subresourceFailure.remaining = Number.MAX_SAFE_INTEGER
-    subresourceFailure.status = 503
+    failure.remaining = Number.MAX_SAFE_INTEGER
+    failure.status = 503
 
     await assert.rejects(
       () => normalize('渋谷区神南1-1-1'),
@@ -135,36 +140,36 @@ describe(`データ取得に失敗したときの挙動`, () => {
       },
     )
     // 初回の要求を含めて 3 回で打ち切る
-    assert.strictEqual(subresourceRequests, 3)
+    assert.strictEqual(targetRequests, 3)
   })
 
   test(`Cloudflare の 52x もリトライの対象になる`, async () => {
     // 配信元の Cloudflare は origin 側の不調に対して 520 から 527 を返す
-    subresourceFailure.remaining = 2
-    subresourceFailure.status = 520
+    failure.remaining = 2
+    failure.status = 520
 
     const res = await normalize('渋谷区恵比寿4-20-3')
 
     assert.strictEqual(res.level, 8)
     assert.strictEqual(res.addr, '20-3')
-    assert.strictEqual(subresourceRequests, 3)
+    assert.strictEqual(targetRequests, 3)
   })
 
   test(`200 でエラーページが返った場合もリトライして回復する`, async () => {
     // Range で要求した長さと本文のバイト長が食い違うことで検知する
-    subresourceFailure.remaining = 1
-    subresourceFailure.status = 200
+    failure.remaining = 1
+    failure.status = 200
 
     const res = await normalize('渋谷区宇田川町15-1')
 
     assert.strictEqual(res.level, 8)
     assert.strictEqual(res.addr, '15-1')
-    assert.strictEqual(subresourceRequests, 2)
+    assert.strictEqual(targetRequests, 2)
   })
 
   test(`200 のエラーページが続く場合は縮退せずにエラーになる`, async () => {
-    subresourceFailure.remaining = Number.MAX_SAFE_INTEGER
-    subresourceFailure.status = 200
+    failure.remaining = Number.MAX_SAFE_INTEGER
+    failure.status = 200
 
     await assert.rejects(
       () => normalize('渋谷区神宮前6-19-13'),
@@ -174,14 +179,27 @@ describe(`データ取得に失敗したときの挙動`, () => {
         return true
       },
     )
-    assert.strictEqual(subresourceRequests, 3)
+    assert.strictEqual(targetRequests, 3)
+  })
+
+  test(`町字データが 200 でエラーページを返した場合もリトライして回復する`, async () => {
+    // JSON として読めない本文は、5xx と同じ一過性の失敗として扱う
+    failure.target = '目黒区.json'
+    failure.remaining = 1
+    failure.status = 200
+
+    const res = await normalize('目黒区五本木1-33-16')
+
+    assert.strictEqual(res.level, 8)
+    assert.strictEqual(res.addr, '33-16')
+    assert.strictEqual(targetRequests, 2)
   })
 
   test(`404 はリトライせずにエラーになる`, async () => {
-    subresourceFailure.remaining = Number.MAX_SAFE_INTEGER
-    subresourceFailure.status = 404
+    failure.remaining = Number.MAX_SAFE_INTEGER
+    failure.status = 404
 
     await assert.rejects(() => normalize('渋谷区桜丘町13-3'))
-    assert.strictEqual(subresourceRequests, 1)
+    assert.strictEqual(targetRequests, 1)
   })
 })

--- a/test/main/filesystem-api.test.ts
+++ b/test/main/filesystem-api.test.ts
@@ -54,10 +54,13 @@ describe(`API stored in filesystem`, () => {
   })
 
   test(`用意されていないエリアはエラーになる`, async () => {
-    try {
-      await normalize('東京都千代田区')
-    } catch (e) {
-      assert.strictEqual(e.code, 'ENOENT')
-    }
+    // try / catch で書くと、例外が投げられなくても素通りで pass してしまう
+    await assert.rejects(
+      () => normalize('東京都千代田区'),
+      (e: Error & { code?: string }) => {
+        assert.strictEqual(e.code, 'ENOENT')
+        return true
+      },
+    )
   })
 })


### PR DESCRIPTION
## 背景

`詳細住所テスト` が「神奈川県厚木市栄町１丁目１－２」で不定期に落ちていました。期待は level 8 ですが、実際には level 3 が返り、番地が `addr` ではなく `other` に残っていました。

これはテストの問題ではなく、ライブラリが取得失敗を握りつぶしていたためです。

`src/lib/cacheRegexes.ts` の 3 箇所の取得処理は、応答の `ok` を一切確認していませんでした。CDN が一過性のエラーを返すと、エラーページの本文をそのまま住所データとして `parseSubresource` に渡すため、住居表示のレコードが 0 件になります。結果として本来 level 8 で解決できる住所が level 3 に縮退し、しかも正常な戻り値として返ります。呼び出し側からは正しい結果と区別が付きません。

一過性の失敗であると判断した根拠です。

- 同じ町字である「神奈川県厚木市栄町１丁目２－２」が、**同じ実行の中で** level 8 で成功している
- 該当の Range リクエストを 15 回試したところ、15 回とも 206 で同一のバイト列が返り、`1,2,,139.360029158,35.439458892` も存在する
- 一度成功しても守られないのは LRU のサイズが原因です。`cacheSize` は 1,000 件ですが、テストデータの町字はユニークで 4,038 件あります。途中で追い出されて再取得が走ります

## 変更内容

`fetchWithRetry` を追加し、`getPrefectures` / `getTowns` / `fetchSubresource` の 3 箇所から呼ぶようにしました。

- `ok` でない応答は例外にする。どのデータの取得に失敗したかをメッセージに含める
- 408 / 425 / 429 / 5xx とネットワークエラーは、指数バックオフで最大 3 回試行する
- 404 や `ENOENT` は再試行しても解決しないため即座に失敗させる

再試行するべき失敗かどうかを判定するために `FetchResponseLike` に `status` を追加しました。ファイルシステムから読む場合などステータスコードの概念が無い実装のために省略可能としています。

## テスト

`test/main/fetch-error.test.ts` を追加しました。ローカルの HTTP サーバーで実データを Range 付きで配信しつつ、住居表示のサブリソースだけ任意の回数だけ失敗させます。

- 一過性の 5xx はリトライして回復する
- 5xx が続く場合は縮退せずにエラーになる
- 404 はリトライせずにエラーになる

修正前は 1 件目が `actual: 3, expected: 8` で落ち、CI で観測された症状をそのまま再現します。残り 2 件は `Missing expected rejection` で落ちます。

## 確認したこと

- `npm test` が 42 件すべて成功（新規 3 件を含む）
- `npm run test:addresses` が 7,191 件すべて成功。縮退が例外に変わったことによる回帰はありません
- `npm run lint` と `npm run build` が通る

## 挙動の変更について

これまで低い level に縮退して返っていたケースが例外になります。利用者から見ると、誤った住所が静かに返るよりも失敗が分かるほうが安全だと判断しました。データに住居表示や地番のレコードが元から無い場合は、これまでどおり `csv_ranges` を見て取得自体を行わないため影響はありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 住所データ取得時の一時的な通信・HTTPエラーに対し、最大3回の自動再試行に対応しました。
  * 応答内容の不備や範囲取得時のデータ長不一致も検出し、再試行します。
  * 再試行不要なエラーは即時通知し、URIやHTTPステータスを含む情報を表示します。
* **バグ修正**
  * HTTP応答ステータスを取得結果で扱えるようになりました。
* **ドキュメント**
  * エラー処理や再試行条件の説明をREADMEに追加しました。
* **テスト**
  * 各種エラーや再試行後の成功、継続失敗を検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->