### PR TITLE
perf: trie-based town matching and regex pre-compilation

### DIFF
--- a/src/lib/cacheRegexes.ts
+++ b/src/lib/cacheRegexes.ts
@@ -53,12 +53,12 @@ async function fetchFromCache<T extends {}>(
   return data
 }
 
-let cachedPrefecturePatterns: [SinglePrefecture, string][] | undefined =
+let cachedPrefecturePatterns: [SinglePrefecture, RegExp][] | undefined =
   undefined
-const cachedCityPatterns: Map<number, [SingleCity, string][]> = new Map()
+const cachedCityPatterns: Map<number, [SingleCity, RegExp][]> = new Map()
 let cachedPrefectures: PrefectureList | undefined = undefined
 const cachedTowns: { [key: string]: TownList } = {}
-let cachedSameNamedPrefectureCityRegexPatterns: [string, string][] | undefined =
+let cachedSameNamedPrefectureCityRegexPatterns: [string, RegExp][] | undefined =
   undefined
 
 export const getPrefectures = async () => {
@@ -81,10 +81,9 @@ export const getPrefectureRegexPatterns = (api: PrefectureApi) => {
   }
 
   const data = api.data
-  cachedPrefecturePatterns = data.map<[SinglePrefecture, string]>((pref) => {
+  cachedPrefecturePatterns = data.map<[SinglePrefecture, RegExp]>((pref) => {
     const _pref = pref.pref.replace(/(都|道|府|県)$/, '') // `東京` の様に末尾の `都府県` が抜けた住所に対応
-    const pattern = `^${_pref}(都|道|府|県)?`
-    return [pref, pattern]
+    return [pref, new RegExp(`^${_pref}(都|道|府|県)?`)]
   })
 
   return cachedPrefecturePatterns
@@ -102,13 +101,13 @@ export const getCityRegexPatterns = (pref: SinglePrefecture) => {
     return cityName(a).length - cityName(b).length
   })
 
-  const patterns = cities.map<[SingleCity, string]>((city) => {
+  const patterns = cities.map<[SingleCity, RegExp]>((city) => {
     const name = cityName(city)
-    let pattern = `^${toRegexPattern(name)}`
+    let patternStr = `^${toRegexPattern(name)}`
     if (name.match(/(町|村)$/)) {
-      pattern = `^${toRegexPattern(name).replace(/(.+?)郡/, '($1郡)?')}` // 郡が省略されてるかも
+      patternStr = `^${toRegexPattern(name).replace(/(.+?)郡/, '($1郡)?')}` // 郡が省略されてるかも
     }
-    return [city, pattern]
+    return [city, new RegExp(patternStr)]
   })
 
   cachedCityPatterns.set(pref.code, patterns)
@@ -345,7 +344,7 @@ export const getTownRegexPatterns = async (
       })
 
       const patterns = towns.map<[SingleMachiAza, string]>((town) => {
-        const pattern = toRegexPattern(
+        const patternStr = toRegexPattern(
           machiAzaName(town)
             // 横棒を含む場合（流通センター、など）に対応
             .replace(/[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━]/g, '[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━]')
@@ -394,7 +393,7 @@ export const getTownRegexPatterns = async (
               },
             ),
         )
-        return ['originalTown' in town ? town.originalTown : town, pattern]
+        return ['originalTown' in town ? town.originalTown : town, patternStr]
       })
 
       // X丁目の丁目なしの数字だけ許容するため、最後に数字だけ追加していく
@@ -407,10 +406,10 @@ export const getTownRegexPatterns = async (
         }
         const chomeNamePart = chomeMatch[1]
         const chomeNum = chomeMatch[2]
-        const pattern = toRegexPattern(
+        const chomePatternStr = toRegexPattern(
           `^${chomeNamePart}(${chomeNum}|${kan2num(chomeNum)})`,
         )
-        patterns.push([town, pattern])
+        patterns.push([town, chomePatternStr])
       }
 
       return patterns
@@ -439,7 +438,7 @@ export const getSameNamedPrefectureCityRegexPatterns = (
         if (cityN.indexOf(_prefs[j]) === 0) {
           cachedSameNamedPrefectureCityRegexPatterns.push([
             `${pref.pref}${cityN}`,
-            `^${cityN}`,
+            new RegExp(`^${cityN}`),
           ])
         }
       }

--- a/src/lib/dict.ts
+++ b/src/lib/dict.ts
@@ -1,6 +1,10 @@
 import { convert } from './dictionaries/convert'
 
+const toRegexPatternCache = new Map<string, string>()
+
 export const toRegexPattern = (string: string) => {
+  const cached = toRegexPatternCache.get(string)
+  if (cached) return cached
   let _str = string
 
   // 以下なるべく文字数が多いものほど上にすること
@@ -36,5 +40,6 @@ export const toRegexPattern = (string: string) => {
 
   _str = convert(_str)
 
+  toRegexPatternCache.set(string, _str)
   return _str
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,4 +1,5 @@
 import { number2kanji } from '@geolonia/japanese-numeral'
+import { dictionary } from './lib/dictionaries/dictionary'
 import { currentConfig } from './config'
 import { kan2num } from './lib/kan2num'
 import { zen2han } from './lib/zen2han'
@@ -96,6 +97,141 @@ const defaultOption = {
   level: 8,
 }
 
+// ---- Trie-based fast path for town matching ----
+
+// Character normalization map: maps variant characters to a single canonical form
+// so both town names and input addresses normalize identically.
+const _nm = new Map<string, string>()
+
+// Old↔new kanji pairs from the dictionary (e.g. 亞→亜)
+for (const e of dictionary) {
+  _nm.set(e.src, e.dst)
+}
+
+// Variant character groups from toRegexPattern
+for (const grp of [
+  ['の', '之', 'ノ'],
+  ['ヶ', 'ケ', 'が'],
+  ['ヵ', 'カ', 'か', '力'],
+  ['ッ', 'ツ', 'っ', 'つ'],
+  ['え', 'エ', 'ヱ'],
+  ['釜', '竈'],
+  ['条', '條'],
+  ['狛', '拍'],
+  ['薮', '藪'],
+  ['淵', '渕'],
+  ['曽', '曾'],
+  ['船', '舟'],
+  ['菟', '莵'],
+  ['崎', '﨑'],
+  ['宜', '冝'],
+]) {
+  const canonical = grp[0]
+  for (let i = 1; i < grp.length; i++) {
+    _nm.set(grp[i], canonical)
+  }
+}
+
+// Full-width digits → half-width
+for (let i = 0; i <= 9; i++) {
+  _nm.set(String.fromCharCode(0xff10 + i), String(i))
+}
+
+// Kanji single digits → arabic (一→1, etc.)
+// Also map ニ(katakana) and ハ(katakana) to match their kanji numeral equivalents
+for (const [k, a] of [
+  ['〇', '0'], ['一', '1'], ['二', '2'], ['三', '3'], ['四', '4'],
+  ['五', '5'], ['六', '6'], ['七', '7'], ['八', '8'], ['九', '9'],
+  ['ニ', '2'], ['ハ', '8'],
+]) {
+  _nm.set(k, a)
+}
+
+// Hyphen variants → '-'
+for (const h of '－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━') {
+  _nm.set(h, '-')
+}
+
+function _nc(ch: string): string {
+  return _nm.get(ch) ?? ch
+}
+
+function _ns(s: string): string {
+  let r = ''
+  for (const ch of s) r += _nc(ch)
+  return r
+}
+
+// Trie node
+interface _TN { c: Map<string, _TN>; t?: SingleMachiAza }
+
+const _trieCache = new Map<string, _TN>()
+
+function _trieInsert(root: _TN, key: string, town: SingleMachiAza) {
+  let node = root
+  for (const ch of key) {
+    let child = node.c.get(ch)
+    if (!child) { child = { c: new Map() }; node.c.set(ch, child) }
+    node = child
+  }
+  if (!node.t) node.t = town
+}
+
+function _trieLookup(root: _TN, input: string): { town: SingleMachiAza; len: number } | null {
+  let node = root
+  let best: { town: SingleMachiAza; len: number } | null = null
+  let i = 0
+  for (const ch of input) {
+    const next = node.c.get(_nc(ch))
+    if (!next) break
+    node = next
+    i++
+    if (node.t) best = { town: node.t, len: i }
+  }
+  return best
+}
+
+// Special alternation mappings from toRegexPattern: input form → canonical form
+// e.g. "三栄町" in an address is actually "四谷三栄町"
+const _altMap: [RegExp, string][] = [
+  [/^三栄町/, '四谷三栄町'],
+  [/^くじ野川/, '鬮野川'],
+  [/^くじの川/, '鬮野川'],
+  [/^柿さき町/, '柿碕町'],
+  [/^とおり/, '通り'],
+  [/^ふ頭/, '埠頭'],
+  [/^番丁/, '番町'],
+  [/^さい/, '穝'],
+  [/^えぶり/, '杁'],
+  [/^ひえ/, '薭'],
+  [/^ヒエ/, '薭'],
+]
+
+function _buildTrie(townPatterns: [SingleMachiAza, string][]): _TN {
+  const root: _TN = { c: new Map() }
+  for (const [town] of townPatterns) {
+    const name = machiAzaName(town)
+    _trieInsert(root, _ns(name), town)
+    // Handle optional 大字/字 prefix
+    if (name.startsWith('大字')) _trieInsert(root, _ns(name.slice(2)), town)
+    if (name.startsWith('字')) _trieInsert(root, _ns(name.slice(1)), town)
+    // Handle special alternation forms (e.g. 四谷三栄町 also matches as 三栄町)
+    for (const [re, canonical] of _altMap) {
+      if (re.test(name)) {
+        const altName = name.replace(re, canonical)
+        _trieInsert(root, _ns(altName), town)
+      }
+      // Also check if this town IS the canonical, add alt form
+      if (name.startsWith(canonical)) {
+        const altForm = re.source.replace(/^\^/, '')
+        const altName = name.replace(canonical, altForm)
+        _trieInsert(root, _ns(altName), town)
+      }
+    }
+  }
+  return root
+}
+
 const normalizeTownName = async (
   input: string,
   pref: SinglePrefecture,
@@ -105,21 +241,29 @@ const normalizeTownName = async (
   input = input.trim().replace(/^大字/, '')
   const townPatterns = await getTownRegexPatterns(pref, city, apiVersion)
 
-  const regexPrefixes = ['^']
-  if (city.city === '京都市') {
-    // 京都は通り名削除のために後方一致を使う
-    regexPrefixes.push('.*')
+  // Fast path: trie lookup
+  const trieKey = `${pref.code}-${city.code}`
+  let trie = _trieCache.get(trieKey)
+  if (!trie) {
+    trie = _buildTrie(townPatterns)
+    _trieCache.set(trieKey, trie)
+  }
+  const trieResult = _trieLookup(trie, input)
+  if (trieResult) {
+    return { town: trieResult.town, other: input.substring(trieResult.len) }
   }
 
+  // Slow path: regex fallback (京都 .*-prefix, complex suffix patterns, etc.)
+  const regexPrefixes = ['^']
+  if (city.city === '京都市') {
+    regexPrefixes.push('.*')
+  }
   for (const regexPrefix of regexPrefixes) {
     for (const [town, pattern] of townPatterns) {
       const regex = new RegExp(`${regexPrefix}${pattern}`)
       const match = input.match(regex)
       if (match) {
-        return {
-          town,
-          other: input.substring(match[0].length),
-        }
+        return { town, other: input.substring(match[0].length) }
       }
     }
   }
@@ -205,7 +349,7 @@ export const normalize: Normalizer = async (
   for (const [prefectureCity, reg] of sameNamedPrefectureCityRegexPatterns) {
     const match = other.match(reg)
     if (match) {
-      other = other.replace(new RegExp(reg), prefectureCity)
+      other = other.replace(reg, prefectureCity)
       break
     }
   }


### PR DESCRIPTION
## Summary

- Add prefix trie for town name matching as a fast path before regex fallback. Normalizes characters (kanji variants, digits, hyphens) to canonical forms for O(name_length) lookups instead of compiling a new RegExp for every town pattern on every call.
- Pre-compile RegExp objects for prefecture, city, and same-named-prefecture-city patterns at cache time.
- Memoize `toRegexPattern` to avoid redundant pattern string computation.

## Benchmark (7188 addresses, level 3)

| Metric | Before | After | Change |
|---|---|---|---|
| Total | 5.87s | ~3.3s | **44% faster** |
| P50 | 0.08ms | 0.03ms | **2.7×** |
| P95 | 2.94ms | 0.10ms | **29×** |
| Throughput | 1225 addr/s | ~2100 addr/s | **1.7×** |
| Correctness | 100% | 100% | same |

## Test plan

- [x] Benchmarked against `test/addresses/addresses.csv` (7188 addresses)
- [x] 100% correctness at level 3
- [x] Regex fallback covers edge cases (京都 `.*`-prefix, complex suffix patterns)
- [ ] Run existing test suite (`npm test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 住所の都道府県・市区町村・町名を、表記ゆれや異体字、数字、ハイフンを含めてより正確に正規化できるようになりました。
  - 町名の検索精度と処理速度を改善し、最長一致による適切な町名判定に対応しました。
  - 同名の都道府県・市区町村を含む住所補完の安定性を向上しました。
  - 繰り返し利用する住所パターンを効率化し、検索や補完をよりスムーズにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->